### PR TITLE
change all static libs to dynamic ones

### DIFF
--- a/recipe/Makefile.debian.SEQ
+++ b/recipe/Makefile.debian.SEQ
@@ -28,7 +28,7 @@ IORDERINGSC = $(IMETIS) $(IPORD) $(ISCOTCH)
 ################################################################################
 
 PLAT    =
-LIBEXT  = .a
+LIBEXT  = .so
 OUTC    = -o
 OUTF    = -o
 RM = /bin/rm -f

--- a/recipe/Makefile.debian.SEQ_mac
+++ b/recipe/Makefile.debian.SEQ_mac
@@ -28,7 +28,7 @@ IORDERINGSC = $(IMETIS) $(IPORD) $(ISCOTCH)
 ################################################################################
 
 PLAT    =
-LIBEXT  = .a
+LIBEXT  = .so
 OUTC    = -o
 OUTF    = -o
 RM = /bin/rm -f

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -7,8 +7,8 @@ else
 fi
 
 make all
-cp lib/*.a ${PREFIX}/lib
-cp libseq/*.a ${PREFIX}/lib
+cp lib/*.so ${PREFIX}/lib
+cp libseq/*.so ${PREFIX}/lib
 cp libseq/*.h ${PREFIX}/include
 cp include/*.h ${PREFIX}/include
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,13 +37,13 @@ requirements:
 
 test:
   commands:
-    - test -f "${PREFIX}/lib/libzmumps.a"
-    - test -f "${PREFIX}/lib/libcmumps.a"
-    - test -f "${PREFIX}/lib/libdmumps.a"
-    - test -f "${PREFIX}/lib/libsmumps.a"
-    - test -f "${PREFIX}/lib/libmumps_common.a"
-    - test -f "${PREFIX}/lib/libpord.a"
-    - test -f "${PREFIX}/lib/libmpiseq.a"
+    - test -f "${PREFIX}/lib/libzmumps.so"
+    - test -f "${PREFIX}/lib/libcmumps.so"
+    - test -f "${PREFIX}/lib/libdmumps.so"
+    - test -f "${PREFIX}/lib/libsmumps.so"
+    - test -f "${PREFIX}/lib/libmumps_common.so"
+    - test -f "${PREFIX}/lib/libpord.so"
+    - test -f "${PREFIX}/lib/libmpiseq.so"
     - test -f "${PREFIX}/include/dmumps_struc.h"
     - test -f "${PREFIX}/include/zmumps_struc.h"
     - test -f "${PREFIX}/include/cmumps_struc.h"


### PR DESCRIPTION
It would be good if mumps was provided as a dynamic library, rather than as a static one. This way when one compiles against it, one does not also need to compile against dynamically-linked dependencies (e.g. metis)