### PR TITLE
Bump build number to 207

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
     - mumps_mpi.patch
 
 build:
-  number: 206
+  number: 207
   skip: true  # [win]
   features:
     - blas_{{ variant }}


### PR DESCRIPTION
Since https://github.com/conda-forge/mumps-feedstock/pull/20 was suddenly merged the build number didn't increase.