### PR TITLE
create mumps-mpi

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-About mumps
-===========
+About mumps-mpi
+===============
 
 Home: http://mumps.enseeiht.fr/
 
@@ -26,28 +26,28 @@ Windows: ![](https://cdn.rawgit.com/conda-forge/conda-smithy/90845bba35bec53edac
 
 Current release info
 ====================
-Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/mumps/badges/version.svg)](https://anaconda.org/conda-forge/mumps)
-Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/mumps/badges/downloads.svg)](https://anaconda.org/conda-forge/mumps)
+Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/mumps-mpi/badges/version.svg)](https://anaconda.org/conda-forge/mumps-mpi)
+Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/mumps-mpi/badges/downloads.svg)](https://anaconda.org/conda-forge/mumps-mpi)
 
-Installing mumps
-================
+Installing mumps-mpi
+====================
 
-Installing `mumps` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
+Installing `mumps-mpi` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
 
 ```
 conda config --add channels conda-forge
 ```
 
-Once the `conda-forge` channel has been enabled, `mumps` can be installed with:
+Once the `conda-forge` channel has been enabled, `mumps-mpi` can be installed with:
 
 ```
-conda install mumps
+conda install mumps-mpi
 ```
 
-It is possible to list all of the versions of `mumps` available on your platform with:
+It is possible to list all of the versions of `mumps-mpi` available on your platform with:
 
 ```
-conda search mumps --channel conda-forge
+conda search mumps-mpi --channel conda-forge
 ```
 
 
@@ -87,17 +87,17 @@ Terminology
                   produce the finished article (built conda distributions)
 
 
-Updating mumps-feedstock
-========================
+Updating mumps-mpi-feedstock
+============================
 
-If you would like to improve the mumps recipe or build a new
+If you would like to improve the mumps-mpi recipe or build a new
 package version, please fork this repository and submit a PR. Upon submission,
 your changes will be run on the appropriate platforms to give the reviewer an
 opportunity to confirm that the changes result in a successful build. Once
 merged, the recipe will be re-built and uploaded automatically to the
 `conda-forge` channel, whereupon the built conda packages will be available for
 everybody to install and use from the `conda-forge` channel.
-Note that all branches in the conda-forge/mumps-feedstock are
+Note that all branches in the conda-forge/mumps-mpi-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
 on branches in forks and branches in the main repository should only be used to
 build distinct package versions.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 207
+  number: 0
   skip: true  # [win]
   features:
     - blas_{{ variant }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,11 +1,11 @@
-{% set name = "mumps" %}
+{% set name = "mumps-mpi" %}
 {% set version = "5.0.2" %}
 {% set sha256 = "77292b204942640256097a3da482c2abcd1e0d5a74ecd1d4bab0f5ef6e60fe45" %}
 {% set variant = "openblas" %}
 {% set mpi = "mpich" %}
 
 package:
-  name: mumps
+  name: {{ name }}
   version: {{ version }}
 
 source:
@@ -14,7 +14,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 206
+  number: 207
   skip: true  # [win]
   features:
     - blas_{{ variant }}


### PR DESCRIPTION
I created the mumps-mpi branch forking master from ea39a08c993bff70e2f1f382ae4a5ffa5b5f751a, the last commit before reverting the parallel builds.

Merging this PR should start building the mumps-mpi package in the mumps-mpi branch by:

- setting name=mumps-mpi
- rerender (only changes README)
- reset build number to 0