### PR TITLE
remove blas_openblas feature

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
     - examples-mpilibs.patch
 
 build:
-  number: 1003
+  number: 1005
 
 requirements:
   build:
@@ -112,8 +112,6 @@ outputs:
       script: ${RECIPE_DIR}/build-mpi.sh
       run_exports:
         - {{ pin_subpackage('mumps-mpi', max_pin='x.x.x') }}  # [not win]
-      features:
-        - blas_{{ variant }}  # [not win]
     requirements:
       build:
         - {{ compiler('fortran') }}  # [not win]


### PR DESCRIPTION
it is being hotfixed out of the blas metapackage
so we don't need it anymore (we never should have added it,
but we couldn't remove it until blas was hotfixed to remove track_features