### PR TITLE
Revert "remove blas_openblas feature"

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -112,6 +112,8 @@ outputs:
       script: ${RECIPE_DIR}/build-mpi.sh
       run_exports:
         - {{ pin_subpackage('mumps-mpi', max_pin='x.x.x') }}  # [not win]
+      features:
+        - blas_{{ variant }}  # [not win]
     requirements:
       build:
         - {{ compiler('fortran') }}  # [not win]


### PR DESCRIPTION
This reverts commit 8a342a59db41833e720970e67174d3cb4c4b3500.

it was premature to remove it. The hotfix that required this change has been reverted.