### PR TITLE
use build.skip for output conditions

### DIFF
--- a/.ci_support/win_.yaml
+++ b/.ci_support/win_.yaml
@@ -2,6 +2,10 @@ channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
+libblas:
+- 3.8 *netlib
+liblapack:
+- 3.8.0 *netlib
 m2w64_c_compiler:
 - m2w64-toolchain
 m2w64_fortran_compiler:

--- a/recipe/CMakeLists.txt
+++ b/recipe/CMakeLists.txt
@@ -29,6 +29,11 @@ if(NOT BLAS_FOUND)
   message(FATAL_ERROR "BLAS not found")
 endif()
 
+find_package(LAPACK)
+if(NOT LAPACK_FOUND)
+  message(FATAL_ERROR "LAPACK not found")
+endif()
+
 # -DWITH_MPI
 option(WITH_MPI "for parallel environment with MPI" OFF)
 if(WITH_MPI)
@@ -242,8 +247,8 @@ examples/${ARCH}simpletest.F
 add_library(${ARCHLIB} SHARED ${CSOURCES} ${FSOURCES})
 target_compile_definitions(${ARCHLIB} PUBLIC MUMPS_ARITH=MUMPS_ARITH_${ARCH} )
 add_executable(${ARCH}simpletest ${EXAMPLE})
-target_link_libraries(${ARCHLIB} mumps_common pord ${BLAS_LIBRARIES})
-target_link_libraries(${ARCH}simpletest ${ARCHLIB} mumps_common pord ${BLAS_LIBRARIES})
+target_link_libraries(${ARCHLIB} mumps_common pord ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES})
+target_link_libraries(${ARCH}simpletest ${ARCHLIB} mumps_common pord ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES})
 install(TARGETS ${ARCHLIB} DESTINATION bin)
 install(FILES include/${ARCH}mumps_struc.h include/${ARCH}mumps_root.h include/${ARCH}mumps_c.h DESTINATION include)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - examples-mpilibs.patch
 
 build:
-  number: 1006
+  number: 1007
 
 requirements:
   build:
@@ -30,25 +30,24 @@ requirements:
     - mpi * {{ mpi }}  # [mpi != 'nompi']
 
 outputs:
-  {% if not win %}
   - name: mumps-include
     build:
       script: ${RECIPE_DIR}/build-headers.sh
+      skip: true  # [win]
     requirements:
       build: []
       host: []
     test:
       commands:
         - test -f "${PREFIX}/include/mumps_compat.h"
-  {% endif %}
 
-  {% if mpi == 'nompi' %}
   - name: mumps-seq
     build:
       script: ${RECIPE_DIR}/build-seq.sh  # [not win]
       script: "%RECIPE_DIR%\\bld-seq.bat"  # [win]
       run_exports:
         - {{ pin_subpackage('mumps-seq', max_pin='x.x.x') }}  # [not win]
+      skip: true  # [mpi != 'nompi']
     requirements:
       build:
         - cmake  # [win]
@@ -100,10 +99,9 @@ outputs:
         - if not exist "%LIBRARY_PREFIX%\mingw-w64\include\dmumps_struc.h" exit 1
         {% endif %}
 
-  {% else %}
   - name: mumps-mpi
     build:
-      skip: true  # [win]
+      skip: true  # [win or mpi == 'nompi']
       script: ${RECIPE_DIR}/build-mpi.sh
       run_exports:
         - {{ pin_subpackage('mumps-mpi', max_pin='x.x.x') }}  # [not win]
@@ -146,7 +144,6 @@ outputs:
         {% endfor %}
         - test ! -f "${PREFIX}/lib/libmpiseq*"
         - test ! -d "${PREFIX}/include/mumps_seq"
-    {% endif %}
 
 about:
   home: http://mumps.enseeiht.fr/


### PR DESCRIPTION
when different outputs are gated by template conditionals, conda_build seems to get confused about which outputs are which during hash computation. build.skip should result in the same outputs with less confusion.

closes #43