### PR TITLE
rebuild to get mpich 3.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - examples-mpilibs.patch
 
 build:
-  number: 4
+  number: 5
 
 requirements:
   build:


### PR DESCRIPTION
#52 did not update to mpich 3.3 because dependencies hadn't been built yet

- [x] ptscotch https://github.com/conda-forge/scotch-feedstock/pull/47
- [x] parmetis https://github.com/conda-forge/parmetis-feedstock/pull/7
- [x] scalapack https://github.com/conda-forge/scalapack-feedstock/pull/11
- [x] verify that builds are picking up mpich 3.3 before merge