### PR TITLE
Win64: Do not skip run_exports directives for mumps-seq

### DIFF
--- a/.ci_support/linux_64_c_compiler_version7fortran_compiler_version7mpimpich.yaml
+++ b/.ci_support/linux_64_c_compiler_version7fortran_compiler_version7mpimpich.yaml
@@ -2,6 +2,8 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '7'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -15,7 +17,7 @@ fortran_compiler_version:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
 metis:
 - '5.1'
 mpi:

--- a/.ci_support/linux_64_c_compiler_version7fortran_compiler_version7mpinompi.yaml
+++ b/.ci_support/linux_64_c_compiler_version7fortran_compiler_version7mpinompi.yaml
@@ -2,6 +2,8 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '7'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -15,7 +17,7 @@ fortran_compiler_version:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
 metis:
 - '5.1'
 mpi:

--- a/.ci_support/linux_64_c_compiler_version7fortran_compiler_version7mpiopenmpi.yaml
+++ b/.ci_support/linux_64_c_compiler_version7fortran_compiler_version7mpiopenmpi.yaml
@@ -2,6 +2,8 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '7'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -15,7 +17,7 @@ fortran_compiler_version:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
 metis:
 - '5.1'
 mpi:

--- a/.ci_support/linux_64_c_compiler_version9fortran_compiler_version9mpimpich.yaml
+++ b/.ci_support/linux_64_c_compiler_version9fortran_compiler_version9mpimpich.yaml
@@ -2,6 +2,8 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '9'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -15,7 +17,7 @@ fortran_compiler_version:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
 metis:
 - '5.1'
 mpi:

--- a/.ci_support/linux_64_c_compiler_version9fortran_compiler_version9mpinompi.yaml
+++ b/.ci_support/linux_64_c_compiler_version9fortran_compiler_version9mpinompi.yaml
@@ -2,6 +2,8 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '9'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -15,7 +17,7 @@ fortran_compiler_version:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
 metis:
 - '5.1'
 mpi:

--- a/.ci_support/linux_64_c_compiler_version9fortran_compiler_version9mpiopenmpi.yaml
+++ b/.ci_support/linux_64_c_compiler_version9fortran_compiler_version9mpiopenmpi.yaml
@@ -2,6 +2,8 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '9'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -15,7 +17,7 @@ fortran_compiler_version:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
 metis:
 - '5.1'
 mpi:

--- a/.ci_support/linux_aarch64_c_compiler_version7fortran_compiler_version7mpimpich.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version7fortran_compiler_version7mpimpich.yaml
@@ -21,7 +21,7 @@ fortran_compiler_version:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
 metis:
 - '5.1'
 mpi:

--- a/.ci_support/linux_aarch64_c_compiler_version7fortran_compiler_version7mpinompi.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version7fortran_compiler_version7mpinompi.yaml
@@ -21,7 +21,7 @@ fortran_compiler_version:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
 metis:
 - '5.1'
 mpi:

--- a/.ci_support/linux_aarch64_c_compiler_version7fortran_compiler_version7mpiopenmpi.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version7fortran_compiler_version7mpiopenmpi.yaml
@@ -21,7 +21,7 @@ fortran_compiler_version:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
 metis:
 - '5.1'
 mpi:

--- a/.ci_support/linux_aarch64_c_compiler_version9fortran_compiler_version9mpimpich.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version9fortran_compiler_version9mpimpich.yaml
@@ -21,7 +21,7 @@ fortran_compiler_version:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
 metis:
 - '5.1'
 mpi:

--- a/.ci_support/linux_aarch64_c_compiler_version9fortran_compiler_version9mpinompi.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version9fortran_compiler_version9mpinompi.yaml
@@ -21,7 +21,7 @@ fortran_compiler_version:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
 metis:
 - '5.1'
 mpi:

--- a/.ci_support/linux_aarch64_c_compiler_version9fortran_compiler_version9mpiopenmpi.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version9fortran_compiler_version9mpiopenmpi.yaml
@@ -21,7 +21,7 @@ fortran_compiler_version:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
 metis:
 - '5.1'
 mpi:

--- a/.ci_support/linux_ppc64le_c_compiler_version8fortran_compiler_version8mpimpich.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version8fortran_compiler_version8mpimpich.yaml
@@ -2,6 +2,8 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '8'
+cdt_name:
+- cos7
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -15,7 +17,7 @@ fortran_compiler_version:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
 metis:
 - '5.1'
 mpi:

--- a/.ci_support/linux_ppc64le_c_compiler_version8fortran_compiler_version8mpinompi.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version8fortran_compiler_version8mpinompi.yaml
@@ -2,6 +2,8 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '8'
+cdt_name:
+- cos7
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -15,7 +17,7 @@ fortran_compiler_version:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
 metis:
 - '5.1'
 mpi:

--- a/.ci_support/linux_ppc64le_c_compiler_version8fortran_compiler_version8mpiopenmpi.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version8fortran_compiler_version8mpiopenmpi.yaml
@@ -2,6 +2,8 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '8'
+cdt_name:
+- cos7
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -15,7 +17,7 @@ fortran_compiler_version:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
 metis:
 - '5.1'
 mpi:

--- a/.ci_support/linux_ppc64le_c_compiler_version9fortran_compiler_version9mpimpich.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version9fortran_compiler_version9mpimpich.yaml
@@ -2,6 +2,8 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '9'
+cdt_name:
+- cos7
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -15,7 +17,7 @@ fortran_compiler_version:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
 metis:
 - '5.1'
 mpi:

--- a/.ci_support/linux_ppc64le_c_compiler_version9fortran_compiler_version9mpinompi.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version9fortran_compiler_version9mpinompi.yaml
@@ -2,6 +2,8 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '9'
+cdt_name:
+- cos7
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -15,7 +17,7 @@ fortran_compiler_version:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
 metis:
 - '5.1'
 mpi:

--- a/.ci_support/linux_ppc64le_c_compiler_version9fortran_compiler_version9mpiopenmpi.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version9fortran_compiler_version9mpiopenmpi.yaml
@@ -2,6 +2,8 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '9'
+cdt_name:
+- cos7
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -15,7 +17,7 @@ fortran_compiler_version:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
 metis:
 - '5.1'
 mpi:

--- a/.ci_support/migrations/scotch609.yaml
+++ b/.ci_support/migrations/scotch609.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-migrator_ts: 1584168513.5428863
-scotch:
-- 6.0.9

--- a/.ci_support/osx_64_fortran_compiler_version7mpimpich.yaml
+++ b/.ci_support/osx_64_fortran_compiler_version7mpimpich.yaml
@@ -15,7 +15,7 @@ fortran_compiler_version:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:

--- a/.ci_support/osx_64_fortran_compiler_version7mpinompi.yaml
+++ b/.ci_support/osx_64_fortran_compiler_version7mpinompi.yaml
@@ -15,7 +15,7 @@ fortran_compiler_version:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:

--- a/.ci_support/osx_64_fortran_compiler_version7mpiopenmpi.yaml
+++ b/.ci_support/osx_64_fortran_compiler_version7mpiopenmpi.yaml
@@ -15,7 +15,7 @@ fortran_compiler_version:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:

--- a/.ci_support/osx_64_fortran_compiler_version9mpimpich.yaml
+++ b/.ci_support/osx_64_fortran_compiler_version9mpimpich.yaml
@@ -15,7 +15,7 @@ fortran_compiler_version:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:

--- a/.ci_support/osx_64_fortran_compiler_version9mpinompi.yaml
+++ b/.ci_support/osx_64_fortran_compiler_version9mpinompi.yaml
@@ -15,7 +15,7 @@ fortran_compiler_version:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:

--- a/.ci_support/osx_64_fortran_compiler_version9mpiopenmpi.yaml
+++ b/.ci_support/osx_64_fortran_compiler_version9mpiopenmpi.yaml
@@ -15,7 +15,7 @@ fortran_compiler_version:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -11,7 +11,7 @@ fortran_compiler_version:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
 mpi:
 - nompi
 target_platform:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -62,7 +62,7 @@ outputs:
         - metis  # [not win]
         - scotch  # [not win]
       run:
-        - {{ pin_subpackage('mumps-include', max_pin='x.x.x') }} 
+        - {{ pin_subpackage('mumps-include', max_pin='x.x.x') }}  # [not win]
         - metis  # [not win]
         - scotch  # [not win]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
     - flang-support.patch
 
 build:
-  number: 9
+  number: 10
   skip: true  # [win and vc<14]
 
 requirements:
@@ -47,7 +47,7 @@ outputs:
       script: ${RECIPE_DIR}/build-seq.sh  # [not win]
       script: "%RECIPE_DIR%\\bld-seq.bat"  # [win]
       run_exports:
-        - {{ pin_subpackage('mumps-seq', max_pin='x.x.x') }}  # [not win]
+        - {{ pin_subpackage('mumps-seq', max_pin='x.x.x') }}
       skip: true  # [(win and vc<14) or mpi != 'nompi']
     requirements:
       build:
@@ -62,7 +62,7 @@ outputs:
         - metis  # [not win]
         - scotch  # [not win]
       run:
-        - {{ pin_subpackage('mumps-include', max_pin='x.x.x') }}  # [not win]
+        - {{ pin_subpackage('mumps-include', max_pin='x.x.x') }} 
         - metis  # [not win]
         - scotch  # [not win]
 


### PR DESCRIPTION
The Windows support was added in https://github.com/conda-forge/mumps-feedstock/pull/56, but the run_exports directly were still decorated by `#[no win]`.  Without this fix, any package that compiles against the shared library provided by `mumps-seq`  need to declare the run dependency on it, but just for Windows, that may result in problems difficult to debug as the test failures in the examples added in https://github.com/conda-forge/ipopt-feedstock/pull/47 .

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

