### PR TITLE
OSX: Drop build-prefix rpath

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -11,27 +11,27 @@ jobs:
       linux_64_c_compiler_version7fortran_compiler_version7mpimpich:
         CONFIG: linux_64_c_compiler_version7fortran_compiler_version7mpimpich
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
       linux_64_c_compiler_version7fortran_compiler_version7mpinompi:
         CONFIG: linux_64_c_compiler_version7fortran_compiler_version7mpinompi
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
       linux_64_c_compiler_version7fortran_compiler_version7mpiopenmpi:
         CONFIG: linux_64_c_compiler_version7fortran_compiler_version7mpiopenmpi
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
       linux_64_c_compiler_version9fortran_compiler_version9mpimpich:
         CONFIG: linux_64_c_compiler_version9fortran_compiler_version9mpimpich
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
       linux_64_c_compiler_version9fortran_compiler_version9mpinompi:
         CONFIG: linux_64_c_compiler_version9fortran_compiler_version9mpinompi
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
       linux_64_c_compiler_version9fortran_compiler_version9mpiopenmpi:
         CONFIG: linux_64_c_compiler_version9fortran_compiler_version9mpiopenmpi
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
   timeoutInMinutes: 360
 
   steps:

--- a/.ci_support/linux_64_c_compiler_version7fortran_compiler_version7mpimpich.yaml
+++ b/.ci_support/linux_64_c_compiler_version7fortran_compiler_version7mpimpich.yaml
@@ -9,7 +9,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-comp7
 fortran_compiler:
 - gfortran
 fortran_compiler_version:

--- a/.ci_support/linux_64_c_compiler_version7fortran_compiler_version7mpinompi.yaml
+++ b/.ci_support/linux_64_c_compiler_version7fortran_compiler_version7mpinompi.yaml
@@ -9,7 +9,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-comp7
 fortran_compiler:
 - gfortran
 fortran_compiler_version:

--- a/.ci_support/linux_64_c_compiler_version7fortran_compiler_version7mpiopenmpi.yaml
+++ b/.ci_support/linux_64_c_compiler_version7fortran_compiler_version7mpiopenmpi.yaml
@@ -9,7 +9,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-comp7
 fortran_compiler:
 - gfortran
 fortran_compiler_version:

--- a/.ci_support/linux_64_c_compiler_version9fortran_compiler_version9mpimpich.yaml
+++ b/.ci_support/linux_64_c_compiler_version9fortran_compiler_version9mpimpich.yaml
@@ -9,7 +9,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-comp7
 fortran_compiler:
 - gfortran
 fortran_compiler_version:

--- a/.ci_support/linux_64_c_compiler_version9fortran_compiler_version9mpinompi.yaml
+++ b/.ci_support/linux_64_c_compiler_version9fortran_compiler_version9mpinompi.yaml
@@ -9,7 +9,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-comp7
 fortran_compiler:
 - gfortran
 fortran_compiler_version:

--- a/.ci_support/linux_64_c_compiler_version9fortran_compiler_version9mpiopenmpi.yaml
+++ b/.ci_support/linux_64_c_compiler_version9fortran_compiler_version9mpiopenmpi.yaml
@@ -9,7 +9,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-comp7
 fortran_compiler:
 - gfortran
 fortran_compiler_version:

--- a/.ci_support/linux_aarch64_c_compiler_version7fortran_compiler_version7mpimpich.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version7fortran_compiler_version7mpimpich.yaml
@@ -13,7 +13,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- condaforge/linux-anvil-aarch64
+- quay.io/condaforge/linux-anvil-aarch64
 fortran_compiler:
 - gfortran
 fortran_compiler_version:

--- a/.ci_support/linux_aarch64_c_compiler_version7fortran_compiler_version7mpinompi.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version7fortran_compiler_version7mpinompi.yaml
@@ -13,7 +13,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- condaforge/linux-anvil-aarch64
+- quay.io/condaforge/linux-anvil-aarch64
 fortran_compiler:
 - gfortran
 fortran_compiler_version:

--- a/.ci_support/linux_aarch64_c_compiler_version7fortran_compiler_version7mpiopenmpi.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version7fortran_compiler_version7mpiopenmpi.yaml
@@ -13,7 +13,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- condaforge/linux-anvil-aarch64
+- quay.io/condaforge/linux-anvil-aarch64
 fortran_compiler:
 - gfortran
 fortran_compiler_version:

--- a/.ci_support/linux_aarch64_c_compiler_version9fortran_compiler_version9mpimpich.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version9fortran_compiler_version9mpimpich.yaml
@@ -13,7 +13,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- condaforge/linux-anvil-aarch64
+- quay.io/condaforge/linux-anvil-aarch64
 fortran_compiler:
 - gfortran
 fortran_compiler_version:

--- a/.ci_support/linux_aarch64_c_compiler_version9fortran_compiler_version9mpinompi.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version9fortran_compiler_version9mpinompi.yaml
@@ -13,7 +13,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- condaforge/linux-anvil-aarch64
+- quay.io/condaforge/linux-anvil-aarch64
 fortran_compiler:
 - gfortran
 fortran_compiler_version:

--- a/.ci_support/linux_aarch64_c_compiler_version9fortran_compiler_version9mpiopenmpi.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version9fortran_compiler_version9mpiopenmpi.yaml
@@ -13,7 +13,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- condaforge/linux-anvil-aarch64
+- quay.io/condaforge/linux-anvil-aarch64
 fortran_compiler:
 - gfortran
 fortran_compiler_version:

--- a/.ci_support/linux_ppc64le_c_compiler_version8fortran_compiler_version8mpimpich.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version8fortran_compiler_version8mpimpich.yaml
@@ -9,7 +9,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- condaforge/linux-anvil-ppc64le
+- quay.io/condaforge/linux-anvil-ppc64le
 fortran_compiler:
 - gfortran
 fortran_compiler_version:

--- a/.ci_support/linux_ppc64le_c_compiler_version8fortran_compiler_version8mpinompi.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version8fortran_compiler_version8mpinompi.yaml
@@ -9,7 +9,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- condaforge/linux-anvil-ppc64le
+- quay.io/condaforge/linux-anvil-ppc64le
 fortran_compiler:
 - gfortran
 fortran_compiler_version:

--- a/.ci_support/linux_ppc64le_c_compiler_version8fortran_compiler_version8mpiopenmpi.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version8fortran_compiler_version8mpiopenmpi.yaml
@@ -9,7 +9,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- condaforge/linux-anvil-ppc64le
+- quay.io/condaforge/linux-anvil-ppc64le
 fortran_compiler:
 - gfortran
 fortran_compiler_version:

--- a/.ci_support/linux_ppc64le_c_compiler_version9fortran_compiler_version9mpimpich.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version9fortran_compiler_version9mpimpich.yaml
@@ -9,7 +9,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- condaforge/linux-anvil-ppc64le
+- quay.io/condaforge/linux-anvil-ppc64le
 fortran_compiler:
 - gfortran
 fortran_compiler_version:

--- a/.ci_support/linux_ppc64le_c_compiler_version9fortran_compiler_version9mpinompi.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version9fortran_compiler_version9mpinompi.yaml
@@ -9,7 +9,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- condaforge/linux-anvil-ppc64le
+- quay.io/condaforge/linux-anvil-ppc64le
 fortran_compiler:
 - gfortran
 fortran_compiler_version:

--- a/.ci_support/linux_ppc64le_c_compiler_version9fortran_compiler_version9mpiopenmpi.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version9fortran_compiler_version9mpiopenmpi.yaml
@@ -9,7 +9,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- condaforge/linux-anvil-ppc64le
+- quay.io/condaforge/linux-anvil-ppc64le
 fortran_compiler:
 - gfortran
 fortran_compiler_version:

--- a/.ci_support/osx_64_fortran_compiler_version7mpimpich.yaml
+++ b/.ci_support/osx_64_fortran_compiler_version7mpimpich.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '10'
+- '11'
 channel_sources:
 - conda-forge,defaults
 channel_targets:

--- a/.ci_support/osx_64_fortran_compiler_version7mpinompi.yaml
+++ b/.ci_support/osx_64_fortran_compiler_version7mpinompi.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '10'
+- '11'
 channel_sources:
 - conda-forge,defaults
 channel_targets:

--- a/.ci_support/osx_64_fortran_compiler_version7mpiopenmpi.yaml
+++ b/.ci_support/osx_64_fortran_compiler_version7mpiopenmpi.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '10'
+- '11'
 channel_sources:
 - conda-forge,defaults
 channel_targets:

--- a/.ci_support/osx_64_fortran_compiler_version9mpimpich.yaml
+++ b/.ci_support/osx_64_fortran_compiler_version9mpimpich.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '10'
+- '11'
 channel_sources:
 - conda-forge,defaults
 channel_targets:

--- a/.ci_support/osx_64_fortran_compiler_version9mpinompi.yaml
+++ b/.ci_support/osx_64_fortran_compiler_version9mpinompi.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '10'
+- '11'
 channel_sources:
 - conda-forge,defaults
 channel_targets:

--- a/.ci_support/osx_64_fortran_compiler_version9mpiopenmpi.yaml
+++ b/.ci_support/osx_64_fortran_compiler_version9mpiopenmpi.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '10'
+- '11'
 channel_sources:
 - conda-forge,defaults
 channel_targets:

--- a/.drone.yml
+++ b/.drone.yml
@@ -8,7 +8,7 @@ platform:
 
 steps:
 - name: Install and build
-  image: condaforge/linux-anvil-aarch64
+  image: quay.io/condaforge/linux-anvil-aarch64
   environment:
     CONFIG: linux_aarch64_c_compiler_version7fortran_compiler_version7mpimpich
     UPLOAD_PACKAGES: True
@@ -39,7 +39,7 @@ platform:
 
 steps:
 - name: Install and build
-  image: condaforge/linux-anvil-aarch64
+  image: quay.io/condaforge/linux-anvil-aarch64
   environment:
     CONFIG: linux_aarch64_c_compiler_version7fortran_compiler_version7mpinompi
     UPLOAD_PACKAGES: True
@@ -70,7 +70,7 @@ platform:
 
 steps:
 - name: Install and build
-  image: condaforge/linux-anvil-aarch64
+  image: quay.io/condaforge/linux-anvil-aarch64
   environment:
     CONFIG: linux_aarch64_c_compiler_version7fortran_compiler_version7mpiopenmpi
     UPLOAD_PACKAGES: True
@@ -101,7 +101,7 @@ platform:
 
 steps:
 - name: Install and build
-  image: condaforge/linux-anvil-aarch64
+  image: quay.io/condaforge/linux-anvil-aarch64
   environment:
     CONFIG: linux_aarch64_c_compiler_version9fortran_compiler_version9mpimpich
     UPLOAD_PACKAGES: True
@@ -132,7 +132,7 @@ platform:
 
 steps:
 - name: Install and build
-  image: condaforge/linux-anvil-aarch64
+  image: quay.io/condaforge/linux-anvil-aarch64
   environment:
     CONFIG: linux_aarch64_c_compiler_version9fortran_compiler_version9mpinompi
     UPLOAD_PACKAGES: True
@@ -163,7 +163,7 @@ platform:
 
 steps:
 - name: Install and build
-  image: condaforge/linux-anvil-aarch64
+  image: quay.io/condaforge/linux-anvil-aarch64
   environment:
     CONFIG: linux_aarch64_c_compiler_version9fortran_compiler_version9mpiopenmpi
     UPLOAD_PACKAGES: True

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,27 +7,27 @@ language: generic
 
 matrix:
   include:
-    - env: CONFIG=linux_ppc64le_c_compiler_version8fortran_compiler_version8mpimpich UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
+    - env: CONFIG=linux_ppc64le_c_compiler_version8fortran_compiler_version8mpimpich UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=quay.io/condaforge/linux-anvil-ppc64le
       os: linux
       arch: ppc64le
 
-    - env: CONFIG=linux_ppc64le_c_compiler_version8fortran_compiler_version8mpinompi UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
+    - env: CONFIG=linux_ppc64le_c_compiler_version8fortran_compiler_version8mpinompi UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=quay.io/condaforge/linux-anvil-ppc64le
       os: linux
       arch: ppc64le
 
-    - env: CONFIG=linux_ppc64le_c_compiler_version8fortran_compiler_version8mpiopenmpi UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
+    - env: CONFIG=linux_ppc64le_c_compiler_version8fortran_compiler_version8mpiopenmpi UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=quay.io/condaforge/linux-anvil-ppc64le
       os: linux
       arch: ppc64le
 
-    - env: CONFIG=linux_ppc64le_c_compiler_version9fortran_compiler_version9mpimpich UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
+    - env: CONFIG=linux_ppc64le_c_compiler_version9fortran_compiler_version9mpimpich UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=quay.io/condaforge/linux-anvil-ppc64le
       os: linux
       arch: ppc64le
 
-    - env: CONFIG=linux_ppc64le_c_compiler_version9fortran_compiler_version9mpinompi UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
+    - env: CONFIG=linux_ppc64le_c_compiler_version9fortran_compiler_version9mpinompi UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=quay.io/condaforge/linux-anvil-ppc64le
       os: linux
       arch: ppc64le
 
-    - env: CONFIG=linux_ppc64le_c_compiler_version9fortran_compiler_version9mpiopenmpi UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
+    - env: CONFIG=linux_ppc64le_c_compiler_version9fortran_compiler_version9mpiopenmpi UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=quay.io/condaforge/linux-anvil-ppc64le
       os: linux
       arch: ppc64le
 

--- a/recipe/build-mpi.sh
+++ b/recipe/build-mpi.sh
@@ -14,4 +14,11 @@ export FC=mpifort
 
 make all
 
+# drop build-prefix rpath
+if [[ "$(uname)" == "Darwin" ]]; then
+  for f in lib/*${PKG_VERSION}.dylib; do
+    ${INSTALL_NAME_TOOL} -delete_rpath ${BUILD_PREFIX}/lib ${f} || echo "delete_rpath failed"
+  done
+fi
+
 cp -av lib/*${SHLIB_EXT} ${PREFIX}/lib

--- a/recipe/build-seq.sh
+++ b/recipe/build-seq.sh
@@ -11,6 +11,13 @@ fi
 
 make all PLAT=_seq
 
+# drop build-prefix rpath
+if [[ "$(uname)" == "Darwin" ]]; then
+  for f in lib/*${PKG_VERSION}.dylib libseq/*${PKG_VERSION}.dylib; do
+    ${INSTALL_NAME_TOOL} -delete_rpath ${BUILD_PREFIX}/lib ${f} || echo "delete_rpath failed"
+  done
+fi
+
 mkdir -p "${PREFIX}/lib"
 mkdir -p "${PREFIX}/include/mumps_seq"
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,8 +18,7 @@ source:
     - flang-support.patch
 
 build:
-  number: 10
-  skip: true  # [win and vc<14]
+  number: 11
 
 requirements:
   build:


### PR DESCRIPTION
The rpaths contain a BUILD_PREFIX entry, delete it to not confuse tools
such as delocate
