### PR TITLE
Attempted fix for missing install name for mumps libraries on osx

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
     - mumps_support_only_metis_5_1_1.patch
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win and vc<14]
 
 requirements:

--- a/recipe/sonamecomma.patch
+++ b/recipe/sonamecomma.patch
@@ -1,6 +1,6 @@
 --- a/src/Makefile
 +++ b/src/Makefile
-@@ -214,14 +214,14 @@
+@@ -214,14 +214,14 @@ $(libdir)/libmumps_common$(PLAT)$(LIBEXT):      $(OBJS_COMMON_MOD) $(OBJS_COMMON
  	$(RANLIB) $@
 
  $(libdir)/libmumps_common$(PLAT)$(LIBEXT_SHARED):      $(OBJS_COMMON_MOD) $(OBJS_COMMON_OTHER)

--- a/recipe/sonamecomma.patch
+++ b/recipe/sonamecomma.patch
@@ -4,8 +4,8 @@
  	$(RANLIB) $@
 
  $(libdir)/libmumps_common$(PLAT)$(LIBEXT_SHARED):      $(OBJS_COMMON_MOD) $(OBJS_COMMON_OTHER)
--	$(FC) $(OPTL) -shared $^ -Wl,$(SONAME),libmumps_common$(PLAT)$(LIBEXT_SHARED) -L$(libdir) $(RPATH_OPT) $(LORDERINGS) $(LIBS) $(LIBOTHERS) -o $@
-+	$(FC) $(OPTL) -shared $^ -Wl,$(SONAME)libmumps_common$(PLAT)$(LIBEXT_SHARED) -L$(libdir) $(RPATH_OPT) $(LORDERINGS) $(LIBS) $(LIBOTHERS) -o $@
+-	$(FC) $(OPTL) -shared $^ -Wl,$(SONAME),libmumps_common$(PLAT)$(LIBEXT_SHARED) -L$(libdir) $(RPATH_OPT) $(LORDERINGS) $(LIBS) $(LIBOTHERS) -o $@ 
++	$(FC) $(OPTL) -shared $^ -Wl,$(SONAME)libmumps_common$(PLAT)$(LIBEXT_SHARED) -L$(libdir) $(RPATH_OPT) $(LORDERINGS) $(LIBS) $(LIBOTHERS) -o $@ 
 
  $(libdir)/lib$(ARITH)mumps$(PLAT)$(LIBEXT):    $(OBJS_MOD) $(OBJS_OTHER)
  	$(AR)$@ $?

--- a/recipe/sonamecomma.patch
+++ b/recipe/sonamecomma.patch
@@ -1,22 +1,19 @@
 --- a/src/Makefile
 +++ b/src/Makefile
-@@ -214,7 +214,7 @@
+@@ -214,14 +214,14 @@
  	$(RANLIB) $@
- 
+
  $(libdir)/libmumps_common$(PLAT)$(LIBEXT_SHARED):      $(OBJS_COMMON_MOD) $(OBJS_COMMON_OTHER)
--	$(FC) $(OPTL) -shared $^ -Wl,$(SONAME),libmumps_common$(PLAT)$(LIBEXT_SHARED) -L$(libdir) $(RPATH_OPT) $(LORDERINGS) $(LIBS) $(LIBOTHERS) -o $@ 
-+	$(FC) $(OPTL) -shared $^ -Wl,$(SONAME)libmumps_common$(PLAT)$(LIBEXT_SHARED) -L$(libdir) $(RPATH_OPT) $(LORDERINGS) $(LIBS) $(LIBOTHERS) -o $@ 
- 
+-	$(FC) $(OPTL) -shared $^ -Wl,$(SONAME),libmumps_common$(PLAT)$(LIBEXT_SHARED) -L$(libdir) $(RPATH_OPT) $(LORDERINGS) $(LIBS) $(LIBOTHERS) -o $@
++	$(FC) $(OPTL) -shared $^ -Wl,$(SONAME)libmumps_common$(PLAT)$(LIBEXT_SHARED) -L$(libdir) $(RPATH_OPT) $(LORDERINGS) $(LIBS) $(LIBOTHERS) -o $@
+
  $(libdir)/lib$(ARITH)mumps$(PLAT)$(LIBEXT):    $(OBJS_MOD) $(OBJS_OTHER)
  	$(AR)$@ $?
---- a/src/Makefile
-+++ b/src/Makefile
-@@ -224,7 +224,7 @@
-	$(RANLIB) $@
+ 	$(RANLIB) $@
 
-$(libdir)/lib$(ARITH)mumps$(PLAT)$(LIBEXT_SHARED):    $(OBJS_MOD) $(OBJS_OTHER) $(libdir)/libmumps_common$(PLAT)$(LIBEXT_SHARED)
+ $(libdir)/lib$(ARITH)mumps$(PLAT)$(LIBEXT_SHARED):    $(OBJS_MOD) $(OBJS_OTHER) $(libdir)/libmumps_common$(PLAT)$(LIBEXT_SHARED)
 -	$(FC) $(OPTL) -shared $(OBJS_MOD) $(OBJS_OTHER) -L$(libdir) $(LORDERINGS) $(LIBS) $(LIBOTHERS) -lmumps_common$(PLAT) -o $@ $(RPATH_OPT)
 +	$(FC) $(OPTL) -shared $(OBJS_MOD) $(OBJS_OTHER) -Wl,$(SONAME)lib$(ARITH)mumps$(PLAT)$(LIBEXT_SHARED) -L$(libdir) $(LORDERINGS) $(LIBS) $(LIBOTHERS) -lmumps_common$(PLAT) -o $@ $(RPATH_OPT)
 
 
-# Dependencies between modules:
+ # Dependencies between modules:

--- a/recipe/sonamecomma.patch
+++ b/recipe/sonamecomma.patch
@@ -9,7 +9,7 @@
  
  $(libdir)/lib$(ARITH)mumps$(PLAT)$(LIBEXT):    $(OBJS_MOD) $(OBJS_OTHER)
  	$(AR)$@ $?
- --- a/src/Makefile
+--- a/src/Makefile
 +++ b/src/Makefile
 @@ -224,7 +224,7 @@
 	$(RANLIB) $@

--- a/recipe/sonamecomma.patch
+++ b/recipe/sonamecomma.patch
@@ -9,3 +9,14 @@
  
  $(libdir)/lib$(ARITH)mumps$(PLAT)$(LIBEXT):    $(OBJS_MOD) $(OBJS_OTHER)
  	$(AR)$@ $?
+ --- a/src/Makefile
++++ b/src/Makefile
+@@ -214,7 +214,7 @@
+	$(RANLIB) $@
+
+$(libdir)/lib$(ARITH)mumps$(PLAT)$(LIBEXT_SHARED):    $(OBJS_MOD) $(OBJS_OTHER) $(libdir)/libmumps_common$(PLAT)$(LIBEXT_SHARED)
+-	$(FC) $(OPTL) -shared $(OBJS_MOD) $(OBJS_OTHER) -L$(libdir) $(LORDERINGS) $(LIBS) $(LIBOTHERS) -lmumps_common$(PLAT) -o $@ $(RPATH_OPT)
++	$(FC) $(OPTL) -shared $(OBJS_MOD) $(OBJS_OTHER) -Wl,$(SONAME)lib$(ARITH)mumps$(PLAT)$(LIBEXT_SHARED) -L$(libdir) $(LORDERINGS) $(LIBS) $(LIBOTHERS) -lmumps_common$(PLAT) -o $@ $(RPATH_OPT)
+
+
+# Dependencies between modules:

--- a/recipe/sonamecomma.patch
+++ b/recipe/sonamecomma.patch
@@ -11,7 +11,7 @@
  	$(AR)$@ $?
  --- a/src/Makefile
 +++ b/src/Makefile
-@@ -214,7 +214,7 @@
+@@ -224,7 +224,7 @@
 	$(RANLIB) $@
 
 $(libdir)/lib$(ARITH)mumps$(PLAT)$(LIBEXT_SHARED):    $(OBJS_MOD) $(OBJS_OTHER) $(libdir)/libmumps_common$(PLAT)$(LIBEXT_SHARED)

--- a/recipe/sonamecomma.patch
+++ b/recipe/sonamecomma.patch
@@ -2,18 +2,18 @@
 +++ b/src/Makefile
 @@ -214,14 +214,14 @@ $(libdir)/libmumps_common$(PLAT)$(LIBEXT):      $(OBJS_COMMON_MOD) $(OBJS_COMMON
  	$(RANLIB) $@
-
+ 
  $(libdir)/libmumps_common$(PLAT)$(LIBEXT_SHARED):      $(OBJS_COMMON_MOD) $(OBJS_COMMON_OTHER)
 -	$(FC) $(OPTL) -shared $^ -Wl,$(SONAME),libmumps_common$(PLAT)$(LIBEXT_SHARED) -L$(libdir) $(RPATH_OPT) $(LORDERINGS) $(LIBS) $(LIBOTHERS) -o $@ 
 +	$(FC) $(OPTL) -shared $^ -Wl,$(SONAME)libmumps_common$(PLAT)$(LIBEXT_SHARED) -L$(libdir) $(RPATH_OPT) $(LORDERINGS) $(LIBS) $(LIBOTHERS) -o $@ 
-
+ 
  $(libdir)/lib$(ARITH)mumps$(PLAT)$(LIBEXT):    $(OBJS_MOD) $(OBJS_OTHER)
  	$(AR)$@ $?
  	$(RANLIB) $@
-
+ 
  $(libdir)/lib$(ARITH)mumps$(PLAT)$(LIBEXT_SHARED):    $(OBJS_MOD) $(OBJS_OTHER) $(libdir)/libmumps_common$(PLAT)$(LIBEXT_SHARED)
 -	$(FC) $(OPTL) -shared $(OBJS_MOD) $(OBJS_OTHER) -L$(libdir) $(LORDERINGS) $(LIBS) $(LIBOTHERS) -lmumps_common$(PLAT) -o $@ $(RPATH_OPT)
 +	$(FC) $(OPTL) -shared $(OBJS_MOD) $(OBJS_OTHER) -Wl,$(SONAME)lib$(ARITH)mumps$(PLAT)$(LIBEXT_SHARED) -L$(libdir) $(LORDERINGS) $(LIBS) $(LIBOTHERS) -lmumps_common$(PLAT) -o $@ $(RPATH_OPT)
-
-
+ 
+ 
  # Dependencies between modules:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

closes #103

<!--
Please add any other relevant info below:
-->

I don't have a lot of experience building mumps, but looking through the downloaded files, this is where I would expect the issue is coming from.