### PR TITLE
build mac with AVOID_MPI_IN_PLACE

### DIFF
--- a/recipe/build-mumps.sh
+++ b/recipe/build-mumps.sh
@@ -38,6 +38,10 @@ fi
 
 if [[ "$target_platform" == osx-* ]]; then
   export SONAME="-install_name"
+
+  # MPI_IN_PLACE seems to cause crashes on mac,
+  # especially with openmpi but now mpich as well
+  export FFLAGS="${FFLAGS} -DAVOID_MPI_IN_PLACE"
   export LDFLAGS="${LDFLAGS} -headerpad_max_install_names"
   function set_soname () {
     install_name_tool -id "@rpath/$(basename $1)" "$1"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,10 +10,11 @@ source:
   url: https://mumps-solver.org/MUMPS_{{ version }}.tar.gz
   sha256: {{ sha256 }}
   patches:
+    - missing-allocok.patch
     - flang-support.patch
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipe/missing-allocok.patch
+++ b/recipe/missing-allocok.patch
@@ -1,0 +1,63 @@
+From c42155ebf2acc171a3ecd5a83b10018a282e2bc4 Mon Sep 17 00:00:00 2001
+From: Min RK <benjaminrk@gmail.com>
+Date: Tue, 30 Apr 2024 13:56:41 +0200
+Subject: [PATCH] add missing allocok with AVOID_MPI_IN_PLACE
+
+---
+ src/csol_c.F | 1 +
+ src/dsol_c.F | 1 +
+ src/ssol_c.F | 1 +
+ src/zsol_c.F | 1 +
+ 4 files changed, 4 insertions(+)
+
+diff --git a/src/csol_c.F b/src/csol_c.F
+index a87b100..a81824d 100644
+--- a/src/csol_c.F
++++ b/src/csol_c.F
+@@ -2512,6 +2512,7 @@ C
+      &           INODE_PRINC, I, II, JAM1
+ #if defined(AVOID_MPI_IN_PLACE)
+       INTEGER, DIMENSION(:), ALLOCATABLE ::  TMP_INT_ARRAY
++      INTEGER allocok
+ #endif
+ #if defined(AVOID_MPI_IN_PLACE)
+       ALLOCATE(TMP_INT_ARRAY(KEEP(28)), STAT = allocok)
+diff --git a/src/dsol_c.F b/src/dsol_c.F
+index d2bfdf2..e36452d 100644
+--- a/src/dsol_c.F
++++ b/src/dsol_c.F
+@@ -2512,6 +2512,7 @@ C
+      &           INODE_PRINC, I, II, JAM1
+ #if defined(AVOID_MPI_IN_PLACE)
+       INTEGER, DIMENSION(:), ALLOCATABLE ::  TMP_INT_ARRAY
++      INTEGER allocok
+ #endif
+ #if defined(AVOID_MPI_IN_PLACE)
+       ALLOCATE(TMP_INT_ARRAY(KEEP(28)), STAT = allocok)
+diff --git a/src/ssol_c.F b/src/ssol_c.F
+index 222c78d..2ee66de 100644
+--- a/src/ssol_c.F
++++ b/src/ssol_c.F
+@@ -2512,6 +2512,7 @@ C
+      &           INODE_PRINC, I, II, JAM1
+ #if defined(AVOID_MPI_IN_PLACE)
+       INTEGER, DIMENSION(:), ALLOCATABLE ::  TMP_INT_ARRAY
++      INTEGER allocok
+ #endif
+ #if defined(AVOID_MPI_IN_PLACE)
+       ALLOCATE(TMP_INT_ARRAY(KEEP(28)), STAT = allocok)
+diff --git a/src/zsol_c.F b/src/zsol_c.F
+index c6a88dc..8ba0193 100644
+--- a/src/zsol_c.F
++++ b/src/zsol_c.F
+@@ -2512,6 +2512,7 @@ C
+      &           INODE_PRINC, I, II, JAM1
+ #if defined(AVOID_MPI_IN_PLACE)
+       INTEGER, DIMENSION(:), ALLOCATABLE ::  TMP_INT_ARRAY
++      INTEGER allocok
+ #endif
+ #if defined(AVOID_MPI_IN_PLACE)
+       ALLOCATE(TMP_INT_ARRAY(KEEP(28)), STAT = allocok)
+-- 
+2.42.0
+


### PR DESCRIPTION
mpi-in-place is causing crashes on mac builds

requires patch for missing `allocok` variable

closes #110 

thanks @dalcinl