### PR TITLE
simplify makefiles

### DIFF
--- a/recipe/Makefile.conda.PAR
+++ b/recipe/Makefile.conda.PAR
@@ -1,65 +1,179 @@
-#
-#  This file is part of MUMPS 5.1.2, released
-#  on Mon Oct  2 07:37:01 UTC 2017
-#
-# These settings for a PC under Debian/linux with standard packages :
-# metis (parmetis), scotch (ptscotch), openmpi, gfortran
+# based on Makefile.inc.generic, MUMPS 5.7.3
 
-# packages installation :
-# apt-get install libmetis-dev libparmetis-dev libscotch-dev libptscotch-dev libatlas-base-dev openmpi-bin libopenmpi-dev lapack-dev
+#  This file is part of MUMPS 5.7.3, released
+#  on Mon Jul 15 11:44:21 UTC 2024
+#
+################################################################################
+#
+#   Makefile.inc.generic
+#
+#   This defines some parameters dependent on your platform; you should
+#   look for the approriate file in the directory ./Make.inc/ and copy it
+#   into a file called Makefile.inc. For example, from the MUMPS root
+#   directory, use 
+#   "cp Make.inc/Makefile.inc.generic ./Makefile.inc"
+#   (see the main README file for details)
+#
+#   If you do not find any suitable Makefile in Makefile.inc, use this file:
+#   "cp Make.inc/Makefile.inc.generic ./Makefile.inc" and modify it according
+#   to the comments given below. If you manage to build MUMPS on a new platform,
+#   and think that this could be useful to others, you may want to send us
+#   the corresponding Makefile.inc file.
+#
+################################################################################
 
-# Begin orderings
-ISCOTCH  = -I$(PREFIX)/include
-LSCOTCH  = -L$(PREFIX)/lib -lptesmumps -lptscotch -lptscotcherr -lscotch
+
+########################################################################
+#Begin orderings
+#
+# NOTE that PORD is distributed within MUMPS by default. It is recommended to
+# install other orderings. For that, you need to obtain the corresponding package
+# and modify the variables below accordingly.
+# For example, to have Metis available within MUMPS:
+#          1/ download Metis and compile it
+#          2/ uncomment (suppress # in first column) lines
+#             starting with LMETISDIR,  LMETIS
+#          3/ add -Dmetis in line ORDERINGSF
+#             ORDERINGSF  = -Dpord -Dmetis
+#          4/ Compile and install MUMPS
+#             make clean; make   (to clean up previous installation)
+#
+#          Metis/ParMetis and SCOTCH/PT-SCOTCH (ver 6.0 and later) orderings are recommended.
+#
+
+ISCOTCH    = -I$(PREFIX)/include
+#
+# You have to choose one among the following two lines depending on
+# the type of analysis you want to perform. If you want to perform only
+# sequential analysis choose the first (remember to add -Dscotch in the ORDERINGSF
+# variable below); for both parallel and sequential analysis choose the second 
+# line (remember to add -Dptscotch in the ORDERINGSF variable below)
+
+#LSCOTCH    = -L$(SCOTCHDIR)/lib -lesmumps -lscotch -lscotcherr
+LSCOTCH    = -L$(PREFIX)/lib -lptesmumps -lptscotch -lptscotcherr -lscotch
+
 
 LPORDDIR = $(topdir)/PORD/lib
 IPORD    = -I$(topdir)/PORD/include
-LPORD    = -L$(LPORDDIR) -lpord
+LPORD    = -L$(LPORDDIR) -lpord$(PLAT)
 
-IMETIS   = -I$(PREFIX)/include
+#LMETISDIR = /opt/metis-5.1.0/build/Linux-x86_64/libmetis
+#IMETIS    = /opt/metis-5.1.0/include
+IMETIS = -I$(PREFIX)/include
+
+# You have to choose one among the following two lines depending on
+# the type of analysis you want to perform. If you want to perform only
+# sequential analysis choose the first (remember to add -Dmetis in the ORDERINGSF
+# variable below); for both parallel and sequential analysis choose the second 
+# line (remember to add -Dparmetis in the ORDERINGSF variable below)
+
+#LMETIS    = -L$(LMETISDIR) -lmetis
 LMETIS   = -L$(PREFIX)/lib -lparmetis -lmetis
 
-# Corresponding variables reused later
+# The following variables will be used in the compilation process.
+# Please note that -Dptscotch and -Dparmetis imply -Dscotch and -Dmetis respectively.
+# If you want to use Metis 4.X or an older version, you should use -Dmetis4 instead of -Dmetis
+# or in addition with -Dparmetis (if you are using parmetis 3.X or older).
+#ORDERINGSF = -Dscotch -Dmetis -Dpord -Dptscotch -Dparmetis
 ORDERINGSF  = -Dparmetis -Dpord -Dptscotch
 ORDERINGSC  = $(ORDERINGSF)
+
 LORDERINGS  = $(LMETIS) $(LPORD) $(LSCOTCH)
 IORDERINGSF = $(ISCOTCH)
 IORDERINGSC = $(IMETIS) $(IPORD) $(ISCOTCH)
-# End orderings
-################################################################################
 
-PLAT    =
+#End orderings
+########################################################################
+
+########################################################################
+# DEFINE HERE SOME COMMON COMMANDS, THE COMPILER NAMES, ETC...
+
+# PLAT : use it to add a default suffix to the generated libraries
+PLAT    = 
+# Suffix for libraries, -soname and -fPIC options, C and Fortran "-o" option
+# may be adapted
+LIBEXT_SHARED = $(SHLIB_EXT)
+# SONAME platform dependent, set in build-mumps.sh
+# SONAME = -soname
+# LDFLAGS/OPTL are missing from libmpi_seq, libpord, pass via SHARED_OPT
+SHARED_OPT = $(LDFLAGS) -shared
+FPIC_OPT = -fPIC
+# Adapt/uncomment RPATH_OPT to avoid modifying
+# LD_LIBRARY_PATH in case of shared libraries
+RPATH_OPT = -Wl,-rpath,$(PREFIX)/lib
 LIBEXT  = .a
 OUTC    = -o
 OUTF    = -o
-RM = /bin/rm -f
-CC := $(CC) -fPIC $(CFLAGS)
-FC := $(FC) -fPIC $(FFLAGS)
-FL := $(FC) $(LDFLAGS)
-AR = ar -ruv #
-RANLIB = ranlib
+# RM : remove files
+RM      = /bin/rm -f
+# CC : C compiler
+CC      := $(CC)
+# FC : Fortran 90 compiler
+FC      := $(FC)
+# FL : Fortran linker
+FL      := $(FC)
+# AR : Archive object in a library
+#      keep a space at the end if options have to be separated from lib name
+AR      = ar vr 
+# RANLIB : generate index of an archive file
+#   (optionnal use "RANLIB = echo" in case of problem)
+RANLIB  = ranlib
+#RANLIB  = echo
 
+# DEFINE HERE YOUR LAPACK LIBRARY
 
-INCSEQ  = -I$(topdir)/libseq
-LIBSEQ  = -L$(topdir)/libseq -lmpiseq
+LAPACK = -L$(PREFIX)/lib -llapack -lblas
 
+# SCALAP should define the SCALAPACK and  BLACS libraries.
 SCALAP  = -L$(PREFIX)/lib -lscalapack
 
+# INCLUDE DIRECTORY FOR MPI
 INCPAR  = -I$(PREFIX)/include
-LIBPAR  = $(SCALAP)
 
-LIBBLAS = -Wl,-rpath,$(PREFIX)/lib -L$(PREFIX)/lib -llapack -lblas
+# LIBRARIES USED BY THE PARALLEL VERSION OF MUMPS: $(SCALAP) and MPI
+LIBPAR  = $(SCALAP) $(LAPACK) -L$(PREFIX)/lib -lmpi
+
+# The parallel version is not concerned by the next two lines.
+# They are related to the sequential library provided by MUMPS,
+# to use instead of ScaLAPACK and MPI.
+INCSEQ  = -I$(PREFIX)/include -I$(PREFIX)/include/mumps_seq -I$(topdir)/libseq
+LIBSEQ  = $(LAPACK) -L$(topdir)/libseq -lmpiseq$(PLAT)
+
+# DEFINE HERE YOUR BLAS LIBRARY
+
+LIBBLAS = -L$(PREFIX)/lib -lblas
+
+# DEFINE HERE YOUR PTHREAD LIBRARY
 LIBOTHERS = -lpthread
 
-#Preprocessor defs for calling Fortran from C (-DAdd_ or -DAdd__ or -DUPPER)
-CDEFS   = -DAdd_
+# FORTRAN/C COMPATIBILITY:
+#  Use:
+#    -DAdd_ if your Fortran compiler adds an underscore at the end
+#              of symbols,
+#     -DAdd__ if your Fortran compiler adds 2 underscores,
+#
+#     -DUPPER if your Fortran compiler uses uppercase symbols
+#
+#     leave empty if your Fortran compiler does not change the symbols.
+#
 
-#Begin Optimized options
-OPTF    = -O -fopenmp -DALLOW_NON_INIT
-OPTL    = -O -fopenmp
-OPTC    = -O -fopenmp
-#End Optimized options
+CDEFS = -DAdd_
 
+#COMPILER OPTIONS
+OMP_OPT = $(fopenmp)
+OPTF    = $(OMP_OPT) $(FFLAGS) -DALLOW_NON_INIT
+OPTC    = $(OMP_OPT) $(CFLAGS)
+OPTL    = $(OMP_OPT) $(LDFLAGS)
+
+# CHOOSE BETWEEN USING THE SEQUENTIAL OR THE PARALLEL VERSION.
+
+#Sequential:
+#INCS = $(INCSEQ)
+#LIBS = $(LIBSEQ)
+#LIBSEQNEEDED = libseqneeded
+
+#Parallel:
 INCS = $(INCPAR)
-LIBS = $(LIBPAR) $(LIBBLAS)
-LIBSEQNEEDED =
+LIBS = $(LIBPAR)
+LIBSEQNEEDED = 
+

--- a/recipe/Makefile.conda.SEQ
+++ b/recipe/Makefile.conda.SEQ
@@ -1,66 +1,11 @@
-#  This file is part of MUMPS 5.0.1, released
-#  on Thu Jul 23 17:08:29 UTC 2015
-#
-# These settings for a PC under Debian/linux with standard packages :
-# metis (parmetis), scotch (ptscotch), mpich, gfortran
+# override the variables that differ between seq/par
+include $(RECIPE_DIR)/Makefile.conda.PAR
 
-# Begin orderings
-LSCOTCH   = -L$(PREFIX)/lib -lesmumps -lscotch -lscotcherr
-ISCOTCH   = -I$(PREFIX)/include
-
-LPORDDIR = $(topdir)/PORD/lib
-IPORD    = -I$(topdir)/PORD/include
-LPORD    = -L$(LPORDDIR) -lpord$(PLAT)
-
-IMETIS    = -I$(PREFIX)/include
-LMETIS    = -L$(PREFIX)/lib -lmetis
-
-# Corresponding variables reused later
+PLAT = _seq
+LSCOTCH = -L$(PREFIX)/lib -lesmumps -lscotch -lscotcherr
 ORDERINGSF = -Dmetis -Dpord -Dscotch
-ORDERINGSC  = $(ORDERINGSF)
-LORDERINGS = $(LMETIS) $(LPORD) $(LSCOTCH)
-IORDERINGSF = $(ISCOTCH)
-IORDERINGSC = $(IMETIS) $(IPORD) $(ISCOTCH)
-# End orderings
-################################################################################
+LMETIS = -L$(PREFIX)/lib -lmetis
 
-PLAT    = _seq
-LIBEXT  = .a
-OUTC    = -o
-OUTF    = -o
-RM = /bin/rm -f
-CC ?= gcc
-CC := $(CC) -fPIC $(CFLAGS)
-FC ?= gfortran
-FC := $(FC) -fPIC $(FFLAGS)
-FL := $(FC) $(LDFLAGS)
-AR = ar -ruv #
-RANLIB = ranlib
-
-
-INCSEQ = -I$(PREFIX)/include -I$(PREFIX)/include/mumps_seq -I$(topdir)/libseq
-LIBSEQ  =  -L$(topdir)/libseq -lmpiseq$(PLAT)
-
-SCALAP =
-
-INCPAR = -I$(PREFIX)/include
-LIBPAR = $(SCALAP) -lmpi -lmpifort -lgfortran
-
-LIBBLAS = -Wl,-rpath,$(PREFIX)/lib -L$(PREFIX)/lib -llapack -lblas
-LIBOTHERS = -lpthread
-
-# debian patch variables for dynamic linking
-MPIFLIB = $(LIBSEQ)
-MPICLIB = $(LIBSEQ)
-
-#Preprocessor defs for calling Fortran from C (-DAdd_ or -DAdd__ or -DUPPER)
-CDEFS   = -DAdd_
-
-#Begin Optimized options
-OPTF    = -O -fopenmp -DALLOW_NON_INIT
-OPTL    = -O -fopenmp
-OPTC    = -O -fopenmp
-#End Optimized options
 INCS = $(INCSEQ)
-LIBS = $(LIBSEQ) $(LIBBLAS)
+LIBS = $(LIBSEQ)
 LIBSEQNEEDED = libseqneeded

--- a/recipe/build-mumps.sh
+++ b/recipe/build-mumps.sh
@@ -53,10 +53,8 @@ else
   }
 fi
 
-# Makefile doesn't accept LDFLAGS in linking, pass via SHARED_OPT
-export LIBEXT_SHARED=${SHLIB_EXT}
+# Makefile doesn't accept LDFLAGS in linking libmpi_seq, libpord, pass via SHARED_OPT
 export SHARED_OPT="${LDFLAGS} -shared"
-export RPATH_OPT="-Wl,-rpath,$PREFIX/lib"
 
 make allshared -j "${CPU_COUNT:-1}"
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - flang-support.patch
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:

--- a/recipe/run_test-mpi.sh
+++ b/recipe/run_test-mpi.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 set -ex
 
-cp "${RECIPE_DIR}/parent/Makefile.conda.PAR" Makefile.inc
+# 'parent' is the _actual_ recipe dir. Not sure why
+export RECIPE_DIR="${RECIPE_DIR}/parent"
+cp -v "${RECIPE_DIR}/Makefile.conda.PAR" Makefile.inc
 cd examples
 
-export LIBEXT_SHARED=${SHLIB_EXT}
 export CC=mpicc
 export FC=mpifort
 

--- a/recipe/run_test-seq.sh
+++ b/recipe/run_test-seq.sh
@@ -1,11 +1,10 @@
 #!/bin/bash
 set -ex
 
-cp "${RECIPE_DIR}/parent/Makefile.conda.SEQ" Makefile.inc
+# 'parent' is the _actual_ recipe dir. Not sure why
+export RECIPE_DIR="${RECIPE_DIR}/parent"
+cp -v "${RECIPE_DIR}/Makefile.conda.SEQ" Makefile.inc
 cd examples
-
-export LIBEXT_SHARED=${SHLIB_EXT}
-export PLAT="_seq"
 
 make clean
 make all


### PR DESCRIPTION
update Makefile.conda.PAR from Makefile.inc.generic in mumps 5.7.3

merges almost entirely identical makefiles into Makefile.conda.PAR. Makefile.conda.SEQ now only overrides what's different, which is very little.

shouldn't change any outputs.

Doing this in it's own PR so it's easy to see _actual_ changes in tackling something like #120 