### PR TITLE
enable GEMMT with openblas

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,51 +8,96 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_mpimpich:
-        CONFIG: linux_64_mpimpich
+      linux_64_blas_implnetlibmpimpich:
+        CONFIG: linux_64_blas_implnetlibmpimpich
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-        SHORT_CONFIG: linux_64_mpimpich
-      linux_64_mpinompi:
-        CONFIG: linux_64_mpinompi
+        SHORT_CONFIG: linux_64_blas_implnetlibmpimpich
+      linux_64_blas_implnetlibmpinompi:
+        CONFIG: linux_64_blas_implnetlibmpinompi
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-        SHORT_CONFIG: linux_64_mpinompi
-      linux_64_mpiopenmpi:
-        CONFIG: linux_64_mpiopenmpi
+        SHORT_CONFIG: linux_64_blas_implnetlibmpinompi
+      linux_64_blas_implnetlibmpiopenmpi:
+        CONFIG: linux_64_blas_implnetlibmpiopenmpi
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-        SHORT_CONFIG: linux_64_mpiopenmpi
-      linux_aarch64_mpimpich:
-        CONFIG: linux_aarch64_mpimpich
+        SHORT_CONFIG: linux_64_blas_implnetlibmpiopenmpi
+      linux_64_blas_implopenblasmpimpich:
+        CONFIG: linux_64_blas_implopenblasmpimpich
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-        SHORT_CONFIG: linux_aarch64_mpimpich
-      linux_aarch64_mpinompi:
-        CONFIG: linux_aarch64_mpinompi
+        SHORT_CONFIG: linux_64_blas_implopenblasmpimpich
+      linux_64_blas_implopenblasmpinompi:
+        CONFIG: linux_64_blas_implopenblasmpinompi
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-        SHORT_CONFIG: linux_aarch64_mpinompi
-      linux_aarch64_mpiopenmpi:
-        CONFIG: linux_aarch64_mpiopenmpi
+        SHORT_CONFIG: linux_64_blas_implopenblasmpinompi
+      linux_64_blas_implopenblasmpiopenmpi:
+        CONFIG: linux_64_blas_implopenblasmpiopenmpi
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-        SHORT_CONFIG: linux_aarch64_mpiopenmpi
-      linux_ppc64le_mpimpich:
-        CONFIG: linux_ppc64le_mpimpich
+        SHORT_CONFIG: linux_64_blas_implopenblasmpiopenmpi
+      linux_aarch64_blas_implnetlibmpimpich:
+        CONFIG: linux_aarch64_blas_implnetlibmpimpich
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-        SHORT_CONFIG: linux_ppc64le_mpimpich
-      linux_ppc64le_mpinompi:
-        CONFIG: linux_ppc64le_mpinompi
+        SHORT_CONFIG: linux_aarch64_blas_implnetlibmpimpich
+      linux_aarch64_blas_implnetlibmpinompi:
+        CONFIG: linux_aarch64_blas_implnetlibmpinompi
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-        SHORT_CONFIG: linux_ppc64le_mpinompi
-      linux_ppc64le_mpiopenmpi:
-        CONFIG: linux_ppc64le_mpiopenmpi
+        SHORT_CONFIG: linux_aarch64_blas_implnetlibmpinompi
+      linux_aarch64_blas_implnetlibmpiopenmpi:
+        CONFIG: linux_aarch64_blas_implnetlibmpiopenmpi
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-        SHORT_CONFIG: linux_ppc64le_mpiopenmpi
+        SHORT_CONFIG: linux_aarch64_blas_implnetlibmpiopenmpi
+      linux_aarch64_blas_implopenblasmpimpich:
+        CONFIG: linux_aarch64_blas_implopenblasmpimpich
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        SHORT_CONFIG: linux_aarch64_blas_implopenblasmpimpich
+      linux_aarch64_blas_implopenblasmpinompi:
+        CONFIG: linux_aarch64_blas_implopenblasmpinompi
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        SHORT_CONFIG: linux_aarch64_blas_implopenblasmpinompi
+      linux_aarch64_blas_implopenblasmpiopenmpi:
+        CONFIG: linux_aarch64_blas_implopenblasmpiopenmpi
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        SHORT_CONFIG: linux_aarch64_blas_implopenblasmpiopenmpi
+      linux_ppc64le_blas_implnetlibmpimpich:
+        CONFIG: linux_ppc64le_blas_implnetlibmpimpich
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        SHORT_CONFIG: linux_ppc64le_blas_implnetlibmpimpich
+      linux_ppc64le_blas_implnetlibmpinompi:
+        CONFIG: linux_ppc64le_blas_implnetlibmpinompi
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        SHORT_CONFIG: linux_ppc64le_blas_implnetlibmpinompi
+      linux_ppc64le_blas_implnetlibmpiopenmpi:
+        CONFIG: linux_ppc64le_blas_implnetlibmpiopenmpi
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        SHORT_CONFIG: linux_ppc64le_blas_implnetlibmpiopenmpi
+      linux_ppc64le_blas_implopenblasmpimpich:
+        CONFIG: linux_ppc64le_blas_implopenblasmpimpich
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        SHORT_CONFIG: linux_ppc64le_blas_implopenblasmpimpich
+      linux_ppc64le_blas_implopenblasmpinompi:
+        CONFIG: linux_ppc64le_blas_implopenblasmpinompi
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        SHORT_CONFIG: linux_ppc64le_blas_implopenblasmpinompi
+      linux_ppc64le_blas_implopenblasmpiopenmpi:
+        CONFIG: linux_ppc64le_blas_implopenblasmpiopenmpi
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        SHORT_CONFIG: linux_ppc64le_blas_implopenblasmpiopenmpi
   timeoutInMinutes: 360
   variables: {}
 

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,30 +8,54 @@ jobs:
     vmImage: macOS-12
   strategy:
     matrix:
-      osx_64_mpimpich:
-        CONFIG: osx_64_mpimpich
+      osx_64_blas_implnetlibmpimpich:
+        CONFIG: osx_64_blas_implnetlibmpimpich
         UPLOAD_PACKAGES: 'True'
-        SHORT_CONFIG: osx_64_mpimpich
-      osx_64_mpinompi:
-        CONFIG: osx_64_mpinompi
+        SHORT_CONFIG: osx_64_blas_implnetlibmpimpich
+      osx_64_blas_implnetlibmpinompi:
+        CONFIG: osx_64_blas_implnetlibmpinompi
         UPLOAD_PACKAGES: 'True'
-        SHORT_CONFIG: osx_64_mpinompi
-      osx_64_mpiopenmpi:
-        CONFIG: osx_64_mpiopenmpi
+        SHORT_CONFIG: osx_64_blas_implnetlibmpinompi
+      osx_64_blas_implnetlibmpiopenmpi:
+        CONFIG: osx_64_blas_implnetlibmpiopenmpi
         UPLOAD_PACKAGES: 'True'
-        SHORT_CONFIG: osx_64_mpiopenmpi
-      osx_arm64_mpimpich:
-        CONFIG: osx_arm64_mpimpich
+        SHORT_CONFIG: osx_64_blas_implnetlibmpiopenmpi
+      osx_64_blas_implopenblasmpimpich:
+        CONFIG: osx_64_blas_implopenblasmpimpich
         UPLOAD_PACKAGES: 'True'
-        SHORT_CONFIG: osx_arm64_mpimpich
-      osx_arm64_mpinompi:
-        CONFIG: osx_arm64_mpinompi
+        SHORT_CONFIG: osx_64_blas_implopenblasmpimpich
+      osx_64_blas_implopenblasmpinompi:
+        CONFIG: osx_64_blas_implopenblasmpinompi
         UPLOAD_PACKAGES: 'True'
-        SHORT_CONFIG: osx_arm64_mpinompi
-      osx_arm64_mpiopenmpi:
-        CONFIG: osx_arm64_mpiopenmpi
+        SHORT_CONFIG: osx_64_blas_implopenblasmpinompi
+      osx_64_blas_implopenblasmpiopenmpi:
+        CONFIG: osx_64_blas_implopenblasmpiopenmpi
         UPLOAD_PACKAGES: 'True'
-        SHORT_CONFIG: osx_arm64_mpiopenmpi
+        SHORT_CONFIG: osx_64_blas_implopenblasmpiopenmpi
+      osx_arm64_blas_implnetlibmpimpich:
+        CONFIG: osx_arm64_blas_implnetlibmpimpich
+        UPLOAD_PACKAGES: 'True'
+        SHORT_CONFIG: osx_arm64_blas_implnetlibmpimpich
+      osx_arm64_blas_implnetlibmpinompi:
+        CONFIG: osx_arm64_blas_implnetlibmpinompi
+        UPLOAD_PACKAGES: 'True'
+        SHORT_CONFIG: osx_arm64_blas_implnetlibmpinompi
+      osx_arm64_blas_implnetlibmpiopenmpi:
+        CONFIG: osx_arm64_blas_implnetlibmpiopenmpi
+        UPLOAD_PACKAGES: 'True'
+        SHORT_CONFIG: osx_arm64_blas_implnetlibmpiopenmpi
+      osx_arm64_blas_implopenblasmpimpich:
+        CONFIG: osx_arm64_blas_implopenblasmpimpich
+        UPLOAD_PACKAGES: 'True'
+        SHORT_CONFIG: osx_arm64_blas_implopenblasmpimpich
+      osx_arm64_blas_implopenblasmpinompi:
+        CONFIG: osx_arm64_blas_implopenblasmpinompi
+        UPLOAD_PACKAGES: 'True'
+        SHORT_CONFIG: osx_arm64_blas_implopenblasmpinompi
+      osx_arm64_blas_implopenblasmpiopenmpi:
+        CONFIG: osx_arm64_blas_implopenblasmpiopenmpi
+        UPLOAD_PACKAGES: 'True'
+        SHORT_CONFIG: osx_arm64_blas_implopenblasmpiopenmpi
   timeoutInMinutes: 360
   variables: {}
 

--- a/.ci_support/linux_64_blas_implnetlibmpimpich.yaml
+++ b/.ci_support/linux_64_blas_implnetlibmpimpich.yaml
@@ -1,0 +1,47 @@
+blas_impl:
+- netlib
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '13'
+libblas:
+- 3.9 *netlib
+liblapack:
+- 3.9 *netlib
+libptscotch:
+- 7.0.4
+libscotch:
+- 7.0.4
+metis:
+- 5.1.0
+mpi:
+- mpich
+mpich:
+- '4'
+openblas:
+- 0.3.*
+openmpi:
+- '5'
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - fortran_compiler_version
+- - c_stdlib_version
+  - cdt_name

--- a/.ci_support/linux_64_blas_implnetlibmpinompi.yaml
+++ b/.ci_support/linux_64_blas_implnetlibmpinompi.yaml
@@ -1,3 +1,5 @@
+blas_impl:
+- netlib
 c_compiler:
 - gcc
 c_compiler_version:
@@ -29,13 +31,15 @@ libscotch:
 metis:
 - 5.1.0
 mpi:
-- openmpi
+- nompi
 mpich:
 - '4'
+openblas:
+- 0.3.*
 openmpi:
 - '5'
 target_platform:
-- linux-ppc64le
+- linux-64
 zip_keys:
 - - c_compiler_version
   - fortran_compiler_version

--- a/.ci_support/linux_64_blas_implnetlibmpiopenmpi.yaml
+++ b/.ci_support/linux_64_blas_implnetlibmpiopenmpi.yaml
@@ -1,0 +1,47 @@
+blas_impl:
+- netlib
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '13'
+libblas:
+- 3.9 *netlib
+liblapack:
+- 3.9 *netlib
+libptscotch:
+- 7.0.4
+libscotch:
+- 7.0.4
+metis:
+- 5.1.0
+mpi:
+- openmpi
+mpich:
+- '4'
+openblas:
+- 0.3.*
+openmpi:
+- '5'
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - fortran_compiler_version
+- - c_stdlib_version
+  - cdt_name

--- a/.ci_support/linux_64_blas_implopenblasmpimpich.yaml
+++ b/.ci_support/linux_64_blas_implopenblasmpimpich.yaml
@@ -1,19 +1,21 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
-MACOSX_SDK_VERSION:
-- '11.0'
+blas_impl:
+- openblas
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '17'
+- '13'
 c_stdlib:
-- macosx_deployment_target
+- sysroot
 c_stdlib_version:
-- '11.0'
+- '2.17'
+cdt_name:
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -26,20 +28,20 @@ libptscotch:
 - 7.0.4
 libscotch:
 - 7.0.4
-llvm_openmp:
-- '17'
-macos_machine:
-- arm64-apple-darwin20.0.0
 metis:
 - 5.1.0
 mpi:
-- openmpi
+- mpich
 mpich:
 - '4'
+openblas:
+- 0.3.*
 openmpi:
 - '5'
 target_platform:
-- osx-arm64
+- linux-64
 zip_keys:
 - - c_compiler_version
   - fortran_compiler_version
+- - c_stdlib_version
+  - cdt_name

--- a/.ci_support/linux_64_blas_implopenblasmpinompi.yaml
+++ b/.ci_support/linux_64_blas_implopenblasmpinompi.yaml
@@ -1,0 +1,47 @@
+blas_impl:
+- openblas
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '13'
+libblas:
+- 3.9 *netlib
+liblapack:
+- 3.9 *netlib
+libptscotch:
+- 7.0.4
+libscotch:
+- 7.0.4
+metis:
+- 5.1.0
+mpi:
+- nompi
+mpich:
+- '4'
+openblas:
+- 0.3.*
+openmpi:
+- '5'
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - fortran_compiler_version
+- - c_stdlib_version
+  - cdt_name

--- a/.ci_support/linux_64_blas_implopenblasmpiopenmpi.yaml
+++ b/.ci_support/linux_64_blas_implopenblasmpiopenmpi.yaml
@@ -1,0 +1,47 @@
+blas_impl:
+- openblas
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '13'
+libblas:
+- 3.9 *netlib
+liblapack:
+- 3.9 *netlib
+libptscotch:
+- 7.0.4
+libscotch:
+- 7.0.4
+metis:
+- 5.1.0
+mpi:
+- openmpi
+mpich:
+- '4'
+openblas:
+- 0.3.*
+openmpi:
+- '5'
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - fortran_compiler_version
+- - c_stdlib_version
+  - cdt_name

--- a/.ci_support/linux_aarch64_blas_implnetlibmpimpich.yaml
+++ b/.ci_support/linux_aarch64_blas_implnetlibmpimpich.yaml
@@ -1,5 +1,7 @@
 BUILD:
 - aarch64-conda_cos7-linux-gnu
+blas_impl:
+- netlib
 c_compiler:
 - gcc
 c_compiler_version:
@@ -33,9 +35,11 @@ libscotch:
 metis:
 - 5.1.0
 mpi:
-- openmpi
+- mpich
 mpich:
 - '4'
+openblas:
+- 0.3.*
 openmpi:
 - '5'
 target_platform:

--- a/.ci_support/linux_aarch64_blas_implnetlibmpinompi.yaml
+++ b/.ci_support/linux_aarch64_blas_implnetlibmpinompi.yaml
@@ -1,0 +1,51 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+blas_impl:
+- netlib
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '13'
+libblas:
+- 3.9 *netlib
+liblapack:
+- 3.9 *netlib
+libptscotch:
+- 7.0.4
+libscotch:
+- 7.0.4
+metis:
+- 5.1.0
+mpi:
+- nompi
+mpich:
+- '4'
+openblas:
+- 0.3.*
+openmpi:
+- '5'
+target_platform:
+- linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - fortran_compiler_version
+- - c_stdlib_version
+  - cdt_name

--- a/.ci_support/linux_aarch64_blas_implnetlibmpiopenmpi.yaml
+++ b/.ci_support/linux_aarch64_blas_implnetlibmpiopenmpi.yaml
@@ -1,3 +1,7 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+blas_impl:
+- netlib
 c_compiler:
 - gcc
 c_compiler_version:
@@ -6,6 +10,8 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
+cdt_arch:
+- aarch64
 cdt_name:
 - cos7
 channel_sources:
@@ -29,13 +35,15 @@ libscotch:
 metis:
 - 5.1.0
 mpi:
-- nompi
+- openmpi
 mpich:
 - '4'
+openblas:
+- 0.3.*
 openmpi:
 - '5'
 target_platform:
-- linux-ppc64le
+- linux-aarch64
 zip_keys:
 - - c_compiler_version
   - fortran_compiler_version

--- a/.ci_support/linux_aarch64_blas_implopenblasmpimpich.yaml
+++ b/.ci_support/linux_aarch64_blas_implopenblasmpimpich.yaml
@@ -1,19 +1,25 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.13'
-MACOSX_SDK_VERSION:
-- '10.13'
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+blas_impl:
+- openblas
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '17'
+- '13'
 c_stdlib:
-- macosx_deployment_target
+- sysroot
 c_stdlib_version:
-- '10.13'
+- '2.17'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -26,20 +32,20 @@ libptscotch:
 - 7.0.4
 libscotch:
 - 7.0.4
-llvm_openmp:
-- '17'
-macos_machine:
-- x86_64-apple-darwin13.4.0
 metis:
 - 5.1.0
 mpi:
-- nompi
+- mpich
 mpich:
 - '4'
+openblas:
+- 0.3.*
 openmpi:
 - '5'
 target_platform:
-- osx-64
+- linux-aarch64
 zip_keys:
 - - c_compiler_version
   - fortran_compiler_version
+- - c_stdlib_version
+  - cdt_name

--- a/.ci_support/linux_aarch64_blas_implopenblasmpinompi.yaml
+++ b/.ci_support/linux_aarch64_blas_implopenblasmpinompi.yaml
@@ -1,5 +1,7 @@
 BUILD:
 - aarch64-conda_cos7-linux-gnu
+blas_impl:
+- openblas
 c_compiler:
 - gcc
 c_compiler_version:
@@ -36,6 +38,8 @@ mpi:
 - nompi
 mpich:
 - '4'
+openblas:
+- 0.3.*
 openmpi:
 - '5'
 target_platform:

--- a/.ci_support/linux_aarch64_blas_implopenblasmpiopenmpi.yaml
+++ b/.ci_support/linux_aarch64_blas_implopenblasmpiopenmpi.yaml
@@ -1,3 +1,7 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+blas_impl:
+- openblas
 c_compiler:
 - gcc
 c_compiler_version:
@@ -6,6 +10,8 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
+cdt_arch:
+- aarch64
 cdt_name:
 - cos7
 channel_sources:
@@ -32,10 +38,12 @@ mpi:
 - openmpi
 mpich:
 - '4'
+openblas:
+- 0.3.*
 openmpi:
 - '5'
 target_platform:
-- linux-64
+- linux-aarch64
 zip_keys:
 - - c_compiler_version
   - fortran_compiler_version

--- a/.ci_support/linux_ppc64le_blas_implnetlibmpimpich.yaml
+++ b/.ci_support/linux_ppc64le_blas_implnetlibmpimpich.yaml
@@ -1,0 +1,47 @@
+blas_impl:
+- netlib
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '13'
+libblas:
+- 3.9 *netlib
+liblapack:
+- 3.9 *netlib
+libptscotch:
+- 7.0.4
+libscotch:
+- 7.0.4
+metis:
+- 5.1.0
+mpi:
+- mpich
+mpich:
+- '4'
+openblas:
+- 0.3.*
+openmpi:
+- '5'
+target_platform:
+- linux-ppc64le
+zip_keys:
+- - c_compiler_version
+  - fortran_compiler_version
+- - c_stdlib_version
+  - cdt_name

--- a/.ci_support/linux_ppc64le_blas_implnetlibmpinompi.yaml
+++ b/.ci_support/linux_ppc64le_blas_implnetlibmpinompi.yaml
@@ -1,19 +1,21 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
-MACOSX_SDK_VERSION:
-- '11.0'
+blas_impl:
+- netlib
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '17'
+- '13'
 c_stdlib:
-- macosx_deployment_target
+- sysroot
 c_stdlib_version:
-- '11.0'
+- '2.17'
+cdt_name:
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -26,20 +28,20 @@ libptscotch:
 - 7.0.4
 libscotch:
 - 7.0.4
-llvm_openmp:
-- '17'
-macos_machine:
-- arm64-apple-darwin20.0.0
 metis:
 - 5.1.0
 mpi:
-- mpich
+- nompi
 mpich:
 - '4'
+openblas:
+- 0.3.*
 openmpi:
 - '5'
 target_platform:
-- osx-arm64
+- linux-ppc64le
 zip_keys:
 - - c_compiler_version
   - fortran_compiler_version
+- - c_stdlib_version
+  - cdt_name

--- a/.ci_support/linux_ppc64le_blas_implnetlibmpiopenmpi.yaml
+++ b/.ci_support/linux_ppc64le_blas_implnetlibmpiopenmpi.yaml
@@ -1,3 +1,5 @@
+blas_impl:
+- netlib
 c_compiler:
 - gcc
 c_compiler_version:
@@ -29,9 +31,11 @@ libscotch:
 metis:
 - 5.1.0
 mpi:
-- mpich
+- openmpi
 mpich:
 - '4'
+openblas:
+- 0.3.*
 openmpi:
 - '5'
 target_platform:

--- a/.ci_support/linux_ppc64le_blas_implopenblasmpimpich.yaml
+++ b/.ci_support/linux_ppc64le_blas_implopenblasmpimpich.yaml
@@ -1,19 +1,21 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.13'
-MACOSX_SDK_VERSION:
-- '10.13'
+blas_impl:
+- openblas
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '17'
+- '13'
 c_stdlib:
-- macosx_deployment_target
+- sysroot
 c_stdlib_version:
-- '10.13'
+- '2.17'
+cdt_name:
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -26,20 +28,20 @@ libptscotch:
 - 7.0.4
 libscotch:
 - 7.0.4
-llvm_openmp:
-- '17'
-macos_machine:
-- x86_64-apple-darwin13.4.0
 metis:
 - 5.1.0
 mpi:
 - mpich
 mpich:
 - '4'
+openblas:
+- 0.3.*
 openmpi:
 - '5'
 target_platform:
-- osx-64
+- linux-ppc64le
 zip_keys:
 - - c_compiler_version
   - fortran_compiler_version
+- - c_stdlib_version
+  - cdt_name

--- a/.ci_support/linux_ppc64le_blas_implopenblasmpinompi.yaml
+++ b/.ci_support/linux_ppc64le_blas_implopenblasmpinompi.yaml
@@ -1,3 +1,5 @@
+blas_impl:
+- openblas
 c_compiler:
 - gcc
 c_compiler_version:
@@ -29,13 +31,15 @@ libscotch:
 metis:
 - 5.1.0
 mpi:
-- mpich
+- nompi
 mpich:
 - '4'
+openblas:
+- 0.3.*
 openmpi:
 - '5'
 target_platform:
-- linux-64
+- linux-ppc64le
 zip_keys:
 - - c_compiler_version
   - fortran_compiler_version

--- a/.ci_support/linux_ppc64le_blas_implopenblasmpiopenmpi.yaml
+++ b/.ci_support/linux_ppc64le_blas_implopenblasmpiopenmpi.yaml
@@ -1,0 +1,47 @@
+blas_impl:
+- openblas
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '13'
+libblas:
+- 3.9 *netlib
+liblapack:
+- 3.9 *netlib
+libptscotch:
+- 7.0.4
+libscotch:
+- 7.0.4
+metis:
+- 5.1.0
+mpi:
+- openmpi
+mpich:
+- '4'
+openblas:
+- 0.3.*
+openmpi:
+- '5'
+target_platform:
+- linux-ppc64le
+zip_keys:
+- - c_compiler_version
+  - fortran_compiler_version
+- - c_stdlib_version
+  - cdt_name

--- a/.ci_support/osx_64_blas_implnetlibmpimpich.yaml
+++ b/.ci_support/osx_64_blas_implnetlibmpimpich.yaml
@@ -1,0 +1,49 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
+blas_impl:
+- netlib
+c_compiler:
+- clang
+c_compiler_version:
+- '17'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '10.13'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '13'
+libblas:
+- 3.9 *netlib
+liblapack:
+- 3.9 *netlib
+libptscotch:
+- 7.0.4
+libscotch:
+- 7.0.4
+llvm_openmp:
+- '17'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+metis:
+- 5.1.0
+mpi:
+- mpich
+mpich:
+- '4'
+openblas:
+- 0.3.*
+openmpi:
+- '5'
+target_platform:
+- osx-64
+zip_keys:
+- - c_compiler_version
+  - fortran_compiler_version

--- a/.ci_support/osx_64_blas_implnetlibmpinompi.yaml
+++ b/.ci_support/osx_64_blas_implnetlibmpinompi.yaml
@@ -1,0 +1,49 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
+blas_impl:
+- netlib
+c_compiler:
+- clang
+c_compiler_version:
+- '17'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '10.13'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '13'
+libblas:
+- 3.9 *netlib
+liblapack:
+- 3.9 *netlib
+libptscotch:
+- 7.0.4
+libscotch:
+- 7.0.4
+llvm_openmp:
+- '17'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+metis:
+- 5.1.0
+mpi:
+- nompi
+mpich:
+- '4'
+openblas:
+- 0.3.*
+openmpi:
+- '5'
+target_platform:
+- osx-64
+zip_keys:
+- - c_compiler_version
+  - fortran_compiler_version

--- a/.ci_support/osx_64_blas_implnetlibmpiopenmpi.yaml
+++ b/.ci_support/osx_64_blas_implnetlibmpiopenmpi.yaml
@@ -1,0 +1,49 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
+blas_impl:
+- netlib
+c_compiler:
+- clang
+c_compiler_version:
+- '17'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '10.13'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '13'
+libblas:
+- 3.9 *netlib
+liblapack:
+- 3.9 *netlib
+libptscotch:
+- 7.0.4
+libscotch:
+- 7.0.4
+llvm_openmp:
+- '17'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+metis:
+- 5.1.0
+mpi:
+- openmpi
+mpich:
+- '4'
+openblas:
+- 0.3.*
+openmpi:
+- '5'
+target_platform:
+- osx-64
+zip_keys:
+- - c_compiler_version
+  - fortran_compiler_version

--- a/.ci_support/osx_64_blas_implopenblasmpimpich.yaml
+++ b/.ci_support/osx_64_blas_implopenblasmpimpich.yaml
@@ -1,7 +1,9 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
+- '10.13'
 MACOSX_SDK_VERSION:
-- '11.0'
+- '10.13'
+blas_impl:
+- openblas
 c_compiler:
 - clang
 c_compiler_version:
@@ -9,7 +11,7 @@ c_compiler_version:
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
-- '11.0'
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -29,17 +31,19 @@ libscotch:
 llvm_openmp:
 - '17'
 macos_machine:
-- arm64-apple-darwin20.0.0
+- x86_64-apple-darwin13.4.0
 metis:
 - 5.1.0
 mpi:
-- nompi
+- mpich
 mpich:
 - '4'
+openblas:
+- 0.3.*
 openmpi:
 - '5'
 target_platform:
-- osx-arm64
+- osx-64
 zip_keys:
 - - c_compiler_version
   - fortran_compiler_version

--- a/.ci_support/osx_64_blas_implopenblasmpinompi.yaml
+++ b/.ci_support/osx_64_blas_implopenblasmpinompi.yaml
@@ -1,0 +1,49 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
+blas_impl:
+- openblas
+c_compiler:
+- clang
+c_compiler_version:
+- '17'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '10.13'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '13'
+libblas:
+- 3.9 *netlib
+liblapack:
+- 3.9 *netlib
+libptscotch:
+- 7.0.4
+libscotch:
+- 7.0.4
+llvm_openmp:
+- '17'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+metis:
+- 5.1.0
+mpi:
+- nompi
+mpich:
+- '4'
+openblas:
+- 0.3.*
+openmpi:
+- '5'
+target_platform:
+- osx-64
+zip_keys:
+- - c_compiler_version
+  - fortran_compiler_version

--- a/.ci_support/osx_64_blas_implopenblasmpiopenmpi.yaml
+++ b/.ci_support/osx_64_blas_implopenblasmpiopenmpi.yaml
@@ -1,19 +1,21 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
+blas_impl:
+- openblas
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '13'
+- '17'
 c_stdlib:
-- sysroot
+- macosx_deployment_target
 c_stdlib_version:
-- '2.17'
-cdt_name:
-- cos7
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -26,18 +28,22 @@ libptscotch:
 - 7.0.4
 libscotch:
 - 7.0.4
+llvm_openmp:
+- '17'
+macos_machine:
+- x86_64-apple-darwin13.4.0
 metis:
 - 5.1.0
 mpi:
-- nompi
+- openmpi
 mpich:
 - '4'
+openblas:
+- 0.3.*
 openmpi:
 - '5'
 target_platform:
-- linux-64
+- osx-64
 zip_keys:
 - - c_compiler_version
   - fortran_compiler_version
-- - c_stdlib_version
-  - cdt_name

--- a/.ci_support/osx_arm64_blas_implnetlibmpimpich.yaml
+++ b/.ci_support/osx_arm64_blas_implnetlibmpimpich.yaml
@@ -1,7 +1,9 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.13'
+- '11.0'
 MACOSX_SDK_VERSION:
-- '10.13'
+- '11.0'
+blas_impl:
+- netlib
 c_compiler:
 - clang
 c_compiler_version:
@@ -9,7 +11,7 @@ c_compiler_version:
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
-- '10.13'
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -29,17 +31,19 @@ libscotch:
 llvm_openmp:
 - '17'
 macos_machine:
-- x86_64-apple-darwin13.4.0
+- arm64-apple-darwin20.0.0
 metis:
 - 5.1.0
 mpi:
-- openmpi
+- mpich
 mpich:
 - '4'
+openblas:
+- 0.3.*
 openmpi:
 - '5'
 target_platform:
-- osx-64
+- osx-arm64
 zip_keys:
 - - c_compiler_version
   - fortran_compiler_version

--- a/.ci_support/osx_arm64_blas_implnetlibmpinompi.yaml
+++ b/.ci_support/osx_arm64_blas_implnetlibmpinompi.yaml
@@ -1,0 +1,49 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+blas_impl:
+- netlib
+c_compiler:
+- clang
+c_compiler_version:
+- '17'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '13'
+libblas:
+- 3.9 *netlib
+liblapack:
+- 3.9 *netlib
+libptscotch:
+- 7.0.4
+libscotch:
+- 7.0.4
+llvm_openmp:
+- '17'
+macos_machine:
+- arm64-apple-darwin20.0.0
+metis:
+- 5.1.0
+mpi:
+- nompi
+mpich:
+- '4'
+openblas:
+- 0.3.*
+openmpi:
+- '5'
+target_platform:
+- osx-arm64
+zip_keys:
+- - c_compiler_version
+  - fortran_compiler_version

--- a/.ci_support/osx_arm64_blas_implnetlibmpiopenmpi.yaml
+++ b/.ci_support/osx_arm64_blas_implnetlibmpiopenmpi.yaml
@@ -1,0 +1,49 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+blas_impl:
+- netlib
+c_compiler:
+- clang
+c_compiler_version:
+- '17'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '13'
+libblas:
+- 3.9 *netlib
+liblapack:
+- 3.9 *netlib
+libptscotch:
+- 7.0.4
+libscotch:
+- 7.0.4
+llvm_openmp:
+- '17'
+macos_machine:
+- arm64-apple-darwin20.0.0
+metis:
+- 5.1.0
+mpi:
+- openmpi
+mpich:
+- '4'
+openblas:
+- 0.3.*
+openmpi:
+- '5'
+target_platform:
+- osx-arm64
+zip_keys:
+- - c_compiler_version
+  - fortran_compiler_version

--- a/.ci_support/osx_arm64_blas_implopenblasmpimpich.yaml
+++ b/.ci_support/osx_arm64_blas_implopenblasmpimpich.yaml
@@ -1,0 +1,49 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+blas_impl:
+- openblas
+c_compiler:
+- clang
+c_compiler_version:
+- '17'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '13'
+libblas:
+- 3.9 *netlib
+liblapack:
+- 3.9 *netlib
+libptscotch:
+- 7.0.4
+libscotch:
+- 7.0.4
+llvm_openmp:
+- '17'
+macos_machine:
+- arm64-apple-darwin20.0.0
+metis:
+- 5.1.0
+mpi:
+- mpich
+mpich:
+- '4'
+openblas:
+- 0.3.*
+openmpi:
+- '5'
+target_platform:
+- osx-arm64
+zip_keys:
+- - c_compiler_version
+  - fortran_compiler_version

--- a/.ci_support/osx_arm64_blas_implopenblasmpinompi.yaml
+++ b/.ci_support/osx_arm64_blas_implopenblasmpinompi.yaml
@@ -1,0 +1,49 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+blas_impl:
+- openblas
+c_compiler:
+- clang
+c_compiler_version:
+- '17'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '13'
+libblas:
+- 3.9 *netlib
+liblapack:
+- 3.9 *netlib
+libptscotch:
+- 7.0.4
+libscotch:
+- 7.0.4
+llvm_openmp:
+- '17'
+macos_machine:
+- arm64-apple-darwin20.0.0
+metis:
+- 5.1.0
+mpi:
+- nompi
+mpich:
+- '4'
+openblas:
+- 0.3.*
+openmpi:
+- '5'
+target_platform:
+- osx-arm64
+zip_keys:
+- - c_compiler_version
+  - fortran_compiler_version

--- a/.ci_support/osx_arm64_blas_implopenblasmpiopenmpi.yaml
+++ b/.ci_support/osx_arm64_blas_implopenblasmpiopenmpi.yaml
@@ -1,23 +1,21 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+blas_impl:
+- openblas
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '13'
+- '17'
 c_stdlib:
-- sysroot
+- macosx_deployment_target
 c_stdlib_version:
-- '2.17'
-cdt_arch:
-- aarch64
-cdt_name:
-- cos7
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -30,18 +28,22 @@ libptscotch:
 - 7.0.4
 libscotch:
 - 7.0.4
+llvm_openmp:
+- '17'
+macos_machine:
+- arm64-apple-darwin20.0.0
 metis:
 - 5.1.0
 mpi:
-- mpich
+- openmpi
 mpich:
 - '4'
+openblas:
+- 0.3.*
 openmpi:
 - '5'
 target_platform:
-- linux-aarch64
+- osx-arm64
 zip_keys:
 - - c_compiler_version
   - fortran_compiler_version
-- - c_stdlib_version
-  - cdt_name

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -1,3 +1,5 @@
+blas_impl:
+- netlib
 c_compiler:
 - vs2019
 c_stdlib:

--- a/README.md
+++ b/README.md
@@ -37,108 +37,213 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64_mpimpich</td>
+              <td>linux_64_blas_implnetlibmpimpich</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=653&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mumps-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_mpimpich" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mumps-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_blas_implnetlibmpimpich" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_mpinompi</td>
+              <td>linux_64_blas_implnetlibmpinompi</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=653&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mumps-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_mpinompi" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mumps-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_blas_implnetlibmpinompi" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_mpiopenmpi</td>
+              <td>linux_64_blas_implnetlibmpiopenmpi</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=653&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mumps-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_mpiopenmpi" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mumps-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_blas_implnetlibmpiopenmpi" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_mpimpich</td>
+              <td>linux_64_blas_implopenblasmpimpich</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=653&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mumps-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_mpimpich" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mumps-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_blas_implopenblasmpimpich" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_mpinompi</td>
+              <td>linux_64_blas_implopenblasmpinompi</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=653&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mumps-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_mpinompi" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mumps-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_blas_implopenblasmpinompi" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_mpiopenmpi</td>
+              <td>linux_64_blas_implopenblasmpiopenmpi</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=653&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mumps-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_mpiopenmpi" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mumps-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_blas_implopenblasmpiopenmpi" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le_mpimpich</td>
+              <td>linux_aarch64_blas_implnetlibmpimpich</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=653&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mumps-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_mpimpich" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mumps-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_blas_implnetlibmpimpich" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le_mpinompi</td>
+              <td>linux_aarch64_blas_implnetlibmpinompi</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=653&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mumps-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_mpinompi" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mumps-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_blas_implnetlibmpinompi" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le_mpiopenmpi</td>
+              <td>linux_aarch64_blas_implnetlibmpiopenmpi</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=653&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mumps-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_mpiopenmpi" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mumps-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_blas_implnetlibmpiopenmpi" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_mpimpich</td>
+              <td>linux_aarch64_blas_implopenblasmpimpich</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=653&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mumps-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_mpimpich" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mumps-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_blas_implopenblasmpimpich" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_mpinompi</td>
+              <td>linux_aarch64_blas_implopenblasmpinompi</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=653&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mumps-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_mpinompi" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mumps-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_blas_implopenblasmpinompi" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_mpiopenmpi</td>
+              <td>linux_aarch64_blas_implopenblasmpiopenmpi</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=653&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mumps-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_mpiopenmpi" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mumps-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_blas_implopenblasmpiopenmpi" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_mpimpich</td>
+              <td>linux_ppc64le_blas_implnetlibmpimpich</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=653&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mumps-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_mpimpich" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mumps-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_blas_implnetlibmpimpich" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_mpinompi</td>
+              <td>linux_ppc64le_blas_implnetlibmpinompi</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=653&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mumps-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_mpinompi" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mumps-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_blas_implnetlibmpinompi" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_mpiopenmpi</td>
+              <td>linux_ppc64le_blas_implnetlibmpiopenmpi</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=653&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mumps-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_mpiopenmpi" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mumps-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_blas_implnetlibmpiopenmpi" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_blas_implopenblasmpimpich</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=653&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mumps-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_blas_implopenblasmpimpich" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_blas_implopenblasmpinompi</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=653&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mumps-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_blas_implopenblasmpinompi" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_blas_implopenblasmpiopenmpi</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=653&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mumps-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_blas_implopenblasmpiopenmpi" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_blas_implnetlibmpimpich</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=653&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mumps-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_blas_implnetlibmpimpich" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_blas_implnetlibmpinompi</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=653&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mumps-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_blas_implnetlibmpinompi" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_blas_implnetlibmpiopenmpi</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=653&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mumps-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_blas_implnetlibmpiopenmpi" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_blas_implopenblasmpimpich</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=653&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mumps-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_blas_implopenblasmpimpich" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_blas_implopenblasmpinompi</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=653&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mumps-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_blas_implopenblasmpinompi" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_blas_implopenblasmpiopenmpi</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=653&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mumps-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_blas_implopenblasmpiopenmpi" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_blas_implnetlibmpimpich</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=653&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mumps-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_blas_implnetlibmpimpich" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_blas_implnetlibmpinompi</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=653&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mumps-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_blas_implnetlibmpinompi" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_blas_implnetlibmpiopenmpi</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=653&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mumps-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_blas_implnetlibmpiopenmpi" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_blas_implopenblasmpimpich</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=653&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mumps-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_blas_implopenblasmpimpich" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_blas_implopenblasmpinompi</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=653&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mumps-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_blas_implopenblasmpinompi" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_blas_implopenblasmpiopenmpi</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=653&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mumps-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_blas_implopenblasmpiopenmpi" alt="variant">
                 </a>
               </td>
             </tr><tr>

--- a/recipe/Makefile.conda.PAR
+++ b/recipe/Makefile.conda.PAR
@@ -122,7 +122,7 @@ RANLIB  = ranlib
 
 # DEFINE HERE YOUR LAPACK LIBRARY
 
-LAPACK = -L$(PREFIX)/lib -llapack -lblas
+LAPACK ?= -L$(PREFIX)/lib -llapack -lblas
 
 # SCALAP should define the SCALAPACK and  BLACS libraries.
 SCALAP  = -L$(PREFIX)/lib -lscalapack
@@ -141,7 +141,7 @@ LIBSEQ  = $(LAPACK) -L$(topdir)/libseq -lmpiseq$(PLAT)
 
 # DEFINE HERE YOUR BLAS LIBRARY
 
-LIBBLAS = -L$(PREFIX)/lib -lblas
+LIBBLAS ?= -L$(PREFIX)/lib -lblas
 
 # DEFINE HERE YOUR PTHREAD LIBRARY
 LIBOTHERS = -lpthread

--- a/recipe/build-mumps.sh
+++ b/recipe/build-mumps.sh
@@ -12,6 +12,17 @@ else
   export PLAT=""
 fi
 
+if [[ "${blas_impl}" != "netlib" ]]; then
+  echo "Enabling DGEMMT"
+  export FFLAGS="${FFLAGS} -DGEMMT_AVAILABLE"
+  if [[ "${blas_impl}" == "openblas" ]]; then
+    export LIBBLAS="-L$PREFIX/lib -lopenblas"
+    export LAPACK="-L$PREFIX/lib -lopenblas"
+  else
+    echo "unexpected blas_impl=${blas_impl}"
+    exit 1
+  fi
+fi
 cp -v $MAKEFILE_INC ./Makefile.inc
 
 

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -2,6 +2,9 @@ mpi:
   - nompi
   - mpich  # [not win]
   - openmpi  # [not win]
+blas_impl:
+  - openblas  # [not win]
+  - netlib
 
 pin_run_as_build:
   parmetis:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,12 @@
 {% set name = "mumps" %}
 {% set version = "5.7.3" %}
 {% set sha256 = "84a47f7c4231b9efdf4d4f631a2cae2bdd9adeaabc088261d15af040143ed112" %}
+{% set build = 4 %}
+
+{% set blas_impl = blas_impl or 'netlib' %}
+{% if blas_impl != "netlib" %}
+{% set build = build + 100 %}
+{% endif %}
 
 package:
   name: mumps
@@ -13,7 +19,7 @@ source:
     - flang-support.patch
 
 build:
-  number: 3
+  number: {{ build }}
 
 requirements:
   build:
@@ -60,8 +66,9 @@ outputs:
         - python 3.11
         - {{ mpi }}  # [mpi == 'openmpi' and build_platform != target_platform]
       host:
-        - libblas
-        - liblapack
+        - libblas  # [blas_impl == "netlib"]
+        - liblapack  # [blas_impl == "netlib"]
+        - openblas  # [blas_impl == "openblas"]
         - metis  # [not win]
         - libscotch  # [not win]
       run:
@@ -144,8 +151,9 @@ outputs:
         - patchelf  # [linux]
         - python
       host:
-        - libblas
-        - liblapack
+        - libblas  # [blas_impl == "netlib"]
+        - liblapack  # [blas_impl == "netlib"]
+        - openblas  # [blas_impl == "openblas"]
         - {{ mpi }}
         - metis
         - parmetis


### PR DESCRIPTION
adds build variant with openblas, with GEMMT enabled. As a result, installing mumps with openblas should get GEMMT by default. Installing mumps with any other blas should still get the most-compatible build targeting netlib.

closes #120 

Draft because I'm still doing some performance testing to see if this is worth doing.