### PR TITLE
openmp builds require openblas openmp builds

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - flang-support.patch
 
 build:
-  number: 3
+  number: 4
 
 requirements:
   build:
@@ -65,8 +65,10 @@ outputs:
         - metis  # [not win]
         - libscotch  # [not win]
       run:
-        - {{ pin_subpackage('mumps-include', max_pin='x.x.x') }}  # [not win]
+        - {{ pin_subpackage('mumps-include', exact=True) }}  # [not win]
         - libscotch  # [not win]
+      run_constrained:
+        - libopenblas * *openmp*
 
     test:
       source_files:
@@ -159,6 +161,8 @@ outputs:
         - libptscotch
         - scalapack
         - libscotch
+      run_constrained:
+        - libopenblas * *openmp*
 
     test:
       source_files:


### PR DESCRIPTION
From the openblas [faq](https://github.com/OpenMathLib/OpenBLAS/wiki/Faq#OpenMP):

> OpenMP provides its own locking mechanisms, so when your code makes BLAS/LAPACK calls from inside OpenMP parallel regions it is imperative that you use an OpenBLAS that is built with USE_OPENMP=1, as otherwise deadlocks might occur. 

This is likely the cause of #125 because the pthreads build of openblas is the default blas on linux, but any package that calls blas from within openmp must require openblas to also use openmp.

hopefully closes #125