### PR TITLE
validate pkg-config output in tests

### DIFF
--- a/recipe/make_pkg_config.py
+++ b/recipe/make_pkg_config.py
@@ -11,7 +11,7 @@ includedir=${{prefix}}/include
 Name: {NAME}
 Description: {DESCRIPTION}
 Version: {VERSION}
-Cflags: -I${{includedir}}
+Cflags: -I${{includedir}}{extra_cflags}
 Libs: -L${{libdir}} -l{NAME}
 """
 
@@ -32,7 +32,7 @@ precision_desc = {
 }
 description_tpl = "The {parallel} {precision}-precision MUMPS library"
 
-def render_one(name, description):
+def render_one(name, description, extra_cflags):
     pc_file = pkgconfig_dir / (name + ".pc")
     print(f"Writing {pc_file}")
     pc_content = tpl.format(
@@ -40,7 +40,7 @@ def render_one(name, description):
         NAME=name,
         VERSION=version,
         DESCRIPTION=description,
-
+        extra_cflags=extra_cflags,
     )
     print(pc_content)
     with pc_file.open("w") as f:
@@ -49,9 +49,11 @@ def render_one(name, description):
 if os.environ["mpi"] == "nompi":
     suffix = "_seq"
     parallel = "sequential"
+    extra_cflags = " -I${includedir}/mumps_seq"
 else:
     suffix = ""
     parallel = "parallel"
+    extra_cflags = ""
 
 for precision in ("s", "d", "c", "z"):
     name = f"{precision}mumps{suffix}"
@@ -59,4 +61,4 @@ for precision in ("s", "d", "c", "z"):
         parallel=parallel,
         precision=precision_desc[precision],
     )
-    render_one(name, description)
+    render_one(name, description, extra_cflags)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - flang-support.patch
 
 build:
-  number: 7
+  number: 8
 
 requirements:
   build:

--- a/recipe/run_test-mpi.sh
+++ b/recipe/run_test-mpi.sh
@@ -1,16 +1,21 @@
 #!/bin/bash
 set -ex
 
-# 'parent' is the _actual_ recipe dir. Not sure why
-export RECIPE_DIR="${RECIPE_DIR}/parent"
-cp -v "${RECIPE_DIR}/Makefile.conda.PAR" Makefile.inc
-cd examples
-
 export CC=mpicc
 export FC=mpifort
 
-make clean
-make all
+set -ex
+
+cd examples
+
+for p in s d c z; do
+  # Check .pc file
+  mumps="${p}mumps"
+  pkg-config --exists --print-errors --debug ${mumps}
+  pkg-config --validate --print-errors --debug ${mumps}
+  $FC ${FFLAGS} ${LDFLAGS} $(pkg-config --cflags ${mumps}) $(pkg-config --libs ${mumps}) ${p}simpletest.F -o ${p}simpletest
+done
+$CC ${CFLAGS} ${LDFLAGS} $(pkg-config --cflags dmumps) $(pkg-config --libs dmumps) c_example.c -o c_example
 
 mpiexec -n 2 ./ssimpletest < input_simpletest_real
 mpiexec -n 2 ./dsimpletest < input_simpletest_real

--- a/recipe/run_test-mpi.sh
+++ b/recipe/run_test-mpi.sh
@@ -11,11 +11,11 @@ cd examples
 for p in s d c z; do
   # Check .pc file
   mumps="${p}mumps"
-  pkg-config --exists --print-errors --debug ${mumps}
-  pkg-config --validate --print-errors --debug ${mumps}
-  $FC ${FFLAGS} ${LDFLAGS} $(pkg-config --cflags ${mumps}) $(pkg-config --libs ${mumps}) ${p}simpletest.F -o ${p}simpletest
+  pkg-config --exists --print-errors ${mumps}
+  pkg-config --validate --print-errors ${mumps}
+  $FC ${FFLAGS} $(pkg-config --cflags ${mumps}) ${p}simpletest.F -o ${p}simpletest ${LDFLAGS} $(pkg-config --libs ${mumps})
 done
-$CC ${CFLAGS} ${LDFLAGS} $(pkg-config --cflags dmumps) $(pkg-config --libs dmumps) c_example.c -o c_example
+$CC ${CFLAGS} $(pkg-config --cflags dmumps) c_example.c -o c_example ${LDFLAGS} $(pkg-config --libs dmumps) 
 
 mpiexec -n 2 ./ssimpletest < input_simpletest_real
 mpiexec -n 2 ./dsimpletest < input_simpletest_real

--- a/recipe/run_test-mpi.sh
+++ b/recipe/run_test-mpi.sh
@@ -13,9 +13,9 @@ for p in s d c z; do
   mumps="${p}mumps"
   pkg-config --exists --print-errors ${mumps}
   pkg-config --validate --print-errors ${mumps}
-  $FC ${FFLAGS} $(pkg-config --cflags ${mumps}) ${p}simpletest.F -o ${p}simpletest ${LDFLAGS} $(pkg-config --libs ${mumps})
+  $FC ${FFLAGS} ${LDFLAGS} $(pkg-config --cflags ${mumps}) ${p}simpletest.F -o ${p}simpletest $(pkg-config --libs ${mumps})
 done
-$CC ${CFLAGS} $(pkg-config --cflags dmumps) c_example.c -o c_example ${LDFLAGS} $(pkg-config --libs dmumps) 
+$CC ${CFLAGS} ${LDFLAGS} $(pkg-config --cflags dmumps) c_example.c -o c_example $(pkg-config --libs dmumps) 
 
 mpiexec -n 2 ./ssimpletest < input_simpletest_real
 mpiexec -n 2 ./dsimpletest < input_simpletest_real

--- a/recipe/run_test-seq.sh
+++ b/recipe/run_test-seq.sh
@@ -1,13 +1,19 @@
 #!/bin/bash
 set -ex
 
-# 'parent' is the _actual_ recipe dir. Not sure why
-export RECIPE_DIR="${RECIPE_DIR}/parent"
-cp -v "${RECIPE_DIR}/Makefile.conda.SEQ" Makefile.inc
 cd examples
 
-make clean
-make all
+# examples link mpiseq directly
+LIBS="-lmpiseq_seq"
+
+for p in s d c z; do
+  # Check .pc file
+  mumps="${p}mumps_seq"
+  pkg-config --exists --print-errors --debug ${mumps}
+  pkg-config --validate --print-errors --debug ${mumps}
+  $FC ${FFLAGS} ${LDFLAGS} ${LIBS} $(pkg-config --cflags ${mumps}) $(pkg-config --libs ${mumps}) ${p}simpletest.F -o ${p}simpletest
+done
+$CC ${CFLAGS} ${LDFLAGS} ${LIBS} $(pkg-config --cflags dmumps_seq) $(pkg-config --libs dmumps_seq) c_example.c -o c_example
 
 ./ssimpletest < input_simpletest_real
 ./dsimpletest < input_simpletest_real

--- a/recipe/run_test-seq.sh
+++ b/recipe/run_test-seq.sh
@@ -9,11 +9,11 @@ LIBS="-lmpiseq_seq"
 for p in s d c z; do
   # Check .pc file
   mumps="${p}mumps_seq"
-  pkg-config --exists --print-errors --debug ${mumps}
-  pkg-config --validate --print-errors --debug ${mumps}
-  $FC ${FFLAGS} ${LDFLAGS} ${LIBS} $(pkg-config --cflags ${mumps}) $(pkg-config --libs ${mumps}) ${p}simpletest.F -o ${p}simpletest
+  pkg-config --exists --print-errors ${mumps}
+  pkg-config --validate --print-errors ${mumps}
+  $FC ${FFLAGS} $(pkg-config --cflags ${mumps}) ${p}simpletest.F -o ${p}simpletest ${LDFLAGS} ${LIBS}  $(pkg-config --libs ${mumps})
 done
-$CC ${CFLAGS} ${LDFLAGS} ${LIBS} $(pkg-config --cflags dmumps_seq) $(pkg-config --libs dmumps_seq) c_example.c -o c_example
+$CC ${CFLAGS} $(pkg-config --cflags dmumps_seq) c_example.c -o c_example ${LDFLAGS} ${LIBS}  $(pkg-config --libs dmumps_seq) 
 
 ./ssimpletest < input_simpletest_real
 ./dsimpletest < input_simpletest_real

--- a/recipe/run_test-seq.sh
+++ b/recipe/run_test-seq.sh
@@ -11,9 +11,9 @@ for p in s d c z; do
   mumps="${p}mumps_seq"
   pkg-config --exists --print-errors ${mumps}
   pkg-config --validate --print-errors ${mumps}
-  $FC ${FFLAGS} $(pkg-config --cflags ${mumps}) ${p}simpletest.F -o ${p}simpletest ${LDFLAGS} ${LIBS}  $(pkg-config --libs ${mumps})
+  $FC ${FFLAGS} ${LDFLAGS} $(pkg-config --cflags ${mumps}) ${p}simpletest.F -o ${p}simpletest ${LIBS}  $(pkg-config --libs ${mumps})
 done
-$CC ${CFLAGS} $(pkg-config --cflags dmumps_seq) c_example.c -o c_example ${LDFLAGS} ${LIBS}  $(pkg-config --libs dmumps_seq) 
+$CC ${CFLAGS} ${LDFLAGS} $(pkg-config --cflags dmumps_seq) c_example.c -o c_example ${LIBS}  $(pkg-config --libs dmumps_seq) 
 
 ./ssimpletest < input_simpletest_real
 ./dsimpletest < input_simpletest_real


### PR DESCRIPTION
build test files with pkg-config output instead of repo Makefiles to ensure it has the right info

and fix missing `-I$PREFIX/include/mumps_seq` for mumps-seq, discovered in https://github.com/conda-forge/ipopt-feedstock/pull/112

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
